### PR TITLE
bazelrc: Add AddressSanitizer config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,3 +27,15 @@ build --cxxopt=-DLONG        # use 8 byte vertex identifiers
 build --cxxopt=-DAMORTIZEDPD # use amortized_bytepd encoding scheme for compressed graphs
 build --cxxopt=-pthread      # necessary for homegrown scheduler
 build --cxxopt=-march=native
+
+# Instruments the build with AddressSanitizer
+# (https://github.com/google/sanitizers/wiki/AddressSanitizer).
+# Invoke by adding the `--config=asan` flag, e.g.,
+#     bazel run --config=asan <build target>`
+build:asan --strip=never
+build:asan --copt -fsanitize=address
+build:asan --copt -O1
+build:asan --copt -g
+build:asan --copt -fno-omit-frame-pointer
+build:asan --linkopt -fsanitize=address
+

--- a/.bazelrc
+++ b/.bazelrc
@@ -38,4 +38,3 @@ build:asan --copt -O1
 build:asan --copt -g
 build:asan --copt -fno-omit-frame-pointer
 build:asan --linkopt -fsanitize=address
-


### PR DESCRIPTION
Adds bazel configuration option to build with (AddressSanitizer)[https://github.com/google/sanitizers/wiki/AddressSanitizer]. 

I've found this useful for debugging issues when developing locally on macOS, which doesn't have `valgrind`. Once we add tests to CI, it maybe also be useful to run tests both under the normal configuration and under this AddressSanitizer configuration.