### PR TITLE
bazelrc: Enable more C++ compiler warnings and fix existing warnings

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,7 +34,9 @@ build --cxxopt=-Wcast-qual
 build --cxxopt=-Wmissing-declarations
 build --cxxopt=-Wno-unused-parameter
 build --cxxopt=-Wpointer-arith
-build --cxxopt=-Wshadow
+# Turning on -Wshadow rather than just -Wshadow=global would be nice, but the
+# code currently contains lots of instances of global shadowing.
+build --cxxopt=-Wshadow=local
 build --cxxopt=-Wvla
 
 # Instruments the build with AddressSanitizer

--- a/.bazelrc
+++ b/.bazelrc
@@ -27,6 +27,17 @@ build --cxxopt=-DAMORTIZEDPD # use amortized_bytepd encoding scheme for compress
 build --cxxopt=-pthread      # necessary for homegrown scheduler
 build --cxxopt=-march=native
 
+# C++ warning flags.
+build --cxxopt=-Wall
+build --cxxopt=-Wextra
+build --cxxopt=-Wcast-qual
+build --cxxopt=-Wlogical-op
+build --cxxopt=-Wmissing-declarations
+build --cxxopt=-Wno-unused-parameter
+build --cxxopt=-Wpointer-arith
+build --cxxopt=-Wshadow
+build --cxxopt=-Wvla
+
 # Instruments the build with AddressSanitizer
 # (https://github.com/google/sanitizers/wiki/AddressSanitizer).
 # Invoke by adding the `--config=asan` flag, e.g.,

--- a/.bazelrc
+++ b/.bazelrc
@@ -31,7 +31,6 @@ build --cxxopt=-march=native
 build --cxxopt=-Wall
 build --cxxopt=-Wextra
 build --cxxopt=-Wcast-qual
-build --cxxopt=-Wmissing-declarations
 build --cxxopt=-Wno-unused-parameter
 build --cxxopt=-Wpointer-arith
 # Turning on -Wshadow rather than just -Wshadow=global would be nice, but the

--- a/.bazelrc
+++ b/.bazelrc
@@ -31,7 +31,6 @@ build --cxxopt=-march=native
 build --cxxopt=-Wall
 build --cxxopt=-Wextra
 build --cxxopt=-Wcast-qual
-build --cxxopt=-Wlogical-op
 build --cxxopt=-Wmissing-declarations
 build --cxxopt=-Wno-unused-parameter
 build --cxxopt=-Wpointer-arith

--- a/benchmarks/ApproximateSetCover/MANISBPT11/ApproximateSetCover.h
+++ b/benchmarks/ApproximateSetCover/MANISBPT11/ApproximateSetCover.h
@@ -173,10 +173,10 @@ inline pbbslib::dyn_arr<uintE> SetCover(Graph& G, size_t num_buckets = 512) {
     auto f = [&](size_t i) -> Maybe<std::tuple<uintE, uintE>> {
       const uintE v = active.vtx(i);
       const uintE v_bkt = D[v];
-      uintE bkt = UINT_E_MAX;
+      uintE bucket = UINT_E_MAX;
       if (!(v_bkt == UINT_E_MAX))
-        bkt = b.get_bucket(v_bkt);
-      return Maybe<std::tuple<uintE, uintE>>(std::make_tuple(v, bkt));
+        bucket = b.get_bucket(v_bkt);
+      return Maybe<std::tuple<uintE, uintE>>(std::make_tuple(v, bucket));
     };
     //std::cout << "cover.size = " << cover.size << "\n";
     b.update_buckets(f, active.size());

--- a/benchmarks/CliqueCounting/BUILD
+++ b/benchmarks/CliqueCounting/BUILD
@@ -88,6 +88,7 @@ cc_library(
   "//ligra:edge_map_reduce",
   "//ligra:ligra",
   "//ligra/pbbslib:dyn_arr",
+  "//pbbslib:assert",
   "//pbbslib:list_allocator",
   "//pbbslib:integer_sort",
   "//benchmarks/DegeneracyOrder/BarenboimElkin08:DegeneracyOrder",

--- a/benchmarks/CliqueCounting/induced_hybrid.h
+++ b/benchmarks/CliqueCounting/induced_hybrid.h
@@ -34,7 +34,7 @@ namespace induced_hybrid {
         uintE* intersect = induced->induced_edges + vtx * induced->nn;
         size_t tmp_counts = 0;
         for (size_t j=0; j < induced->induced_degs[vtx]; j++) {
-          if (induced->labels[intersect[j]] == k_idx) {
+          if (static_cast<size_t>(induced->labels[intersect[j]]) == k_idx) {
             tmp_counts++;
             if (induced->use_base) base_f(induced->relabel[intersect[j]], 1);
           }
@@ -53,7 +53,7 @@ if (recursive_level < k_idx || num_induced < 2) {
       uintE* out = induced->induced + induced->nn * k_idx;
       uintE count = 0;
       for (size_t j=0; j < induced->induced_degs[vtx]; j++) {
-        if (induced->labels[intersect[j]] == k_idx) {
+        if (static_cast<size_t>(induced->labels[intersect[j]]) == k_idx) {
           out[count] = intersect[j];
           count++;
         }
@@ -76,7 +76,7 @@ if (recursive_level < k_idx || num_induced < 2) {
       uintE* out = induced2->induced;
       uintE count = 0;
       for (size_t j=0; j < induced->induced_degs[vtx]; j++) {
-        if (induced->labels[intersect[j]] == k_idx) {
+        if (static_cast<size_t>(induced->labels[intersect[j]]) == k_idx) {
           out[count] = intersect[j];
           count++;
         }
@@ -98,7 +98,6 @@ if (recursive_level < k_idx || num_induced < 2) {
   template <class Graph, class F>
   inline size_t CountCliques(Graph& DG, size_t k, F base_f, bool use_base=false, bool label=true, long recursive_level=0) {
     timer t2; t2.start();
-    using W = typename Graph::weight_type;
 
     if (recursive_level != 1) {
       sequence<size_t> tots = sequence<size_t>::no_init(DG.n);

--- a/benchmarks/CliqueCounting/induced_intersection.h
+++ b/benchmarks/CliqueCounting/induced_intersection.h
@@ -27,7 +27,7 @@ namespace induced_intersection {
 
     auto tmp = sequence<std::tuple<uintE, W>>(num_induced);
     auto pred = [&] (const uintE& src, const uintE& nbhr, const W& wgh) {
-      return (induced->intersect[nbhr] == k_idx);
+      return (static_cast<size_t>(induced->intersect[nbhr]) == k_idx);
     };
 
     if (k_idx + 1 == k) {

--- a/benchmarks/CliqueCounting/induced_split.h
+++ b/benchmarks/CliqueCounting/induced_split.h
@@ -6,16 +6,6 @@
 /* TODO: describe what this file does */
 
 namespace induced_split {
-  template<class Graph>
-  size_t get_max_deg(Graph& DG) {
-    size_t max_deg = 0;
-    parallel_for(0, DG.n, [&] (size_t i) {
-      size_t deg = DG.get_vertex(i).getOutDegree();
-      pbbs::write_min(&max_deg, deg, std::greater<size_t>());
-    });
-    return max_deg;
-  }
-
   template <class Graph, class F>
   inline size_t CountCliques(Graph& DG, size_t k, F base_f, bool use_base=false, bool label=true, long recursive_level=0) {
     timer t; t.start();
@@ -41,7 +31,6 @@ namespace induced_split {
 
     timer t2; t2.start();
     sequence<size_t> tots = sequence<size_t>::no_init(n_blocks); //DG.n
-    size_t max_deg = get_max_deg(DG);
     parallel_for(0, n_blocks, [&](size_t j) {
       size_t start = j * work_per_block;
       size_t end = (j + 1) * work_per_block;

--- a/benchmarks/CliqueCounting/relabel.h
+++ b/benchmarks/CliqueCounting/relabel.h
@@ -108,7 +108,7 @@ inline symmetric_graph<csv_byte, W> relabel_graph(symmetric_graph<vertex, W>& GA
       }, true);
 
       auto iter = vertex_ops::get_iter(tmp_edges.begin(), deg);
-      size_t nbytes = byte::sequentialCompressEdgeSet<W>(
+      byte::sequentialCompressEdgeSet<W>(
           edges.begin() + byte_offsets[rank[i]], 0, deg, rank[i], iter);
     }
   }, 1);
@@ -170,12 +170,12 @@ inline symmetric_graph<symmetric_vertex, W> relabel_graph(symmetric_graph<vertex
       auto pred_c = [&](const edge& e) {
         return pred(i, std::get<0>(e), std::get<1>(e));
       };
-      auto n_im_f = [&](size_t i) { return nghs[i]; };
+      auto n_im_f = [&](size_t j) { return nghs[j]; };
       auto n_im = pbbslib::make_sequence<edge>(d, n_im_f);
       pbbslib::filter_out(n_im, pbbslib::make_sequence(dir_nghs, d), pred_c, pbbslib::no_flag);
       parallel_for(0, true_deg, [&] (size_t j) { dir_nghs[j] = std::make_tuple(rank[std::get<0>(dir_nghs[j])], std::get<1>(dir_nghs[j])); });
-      pbbslib::sample_sort (dir_nghs, true_deg, [&](const edge u, const edge v) {
-        return std::get<0>(u) < std::get<0>(v);
+      pbbslib::sample_sort (dir_nghs, true_deg, [&](const edge left, const edge right) {
+        return std::get<0>(left) < std::get<0>(right);
       }, true);
     }
   }, 1);
@@ -200,7 +200,6 @@ template <class Graph>
 auto clr_sparsify_graph(Graph& GA, size_t denom, long seed) {
   using W = typename Graph::weight_type;
   size_t n = GA.n;
-  double p = 1/denom;
   // Color vertices with denom colors
   uintE numColors = std::max((size_t) 1,denom);
   sequence<uintE> colors = sequence<uintE>(n, [&](size_t i){ return pbbs::hash64_2((uintE) seed+i) % numColors; });

--- a/benchmarks/IntegralWeightSSSP/JulienneDBS17/wBFS.h
+++ b/benchmarks/IntegralWeightSSSP/JulienneDBS17/wBFS.h
@@ -84,10 +84,10 @@ inline sequence<uintE> wBFS(Graph& G, uintE src,
   auto dists = sequence<uintE>(n, [&](size_t i) { return INT_E_MAX; });
   dists[src] = 0;
 
-  auto get_bkt = [&](const uintE& dist) -> const uintE {
+  auto get_bkt = [&](const uintE& dist) -> uintE {
     return (dist == INT_E_MAX) ? UINT_E_MAX : dist;
   };
-  auto get_ring = pbbslib::make_sequence<uintE>(n, [&](const size_t& v) -> const uintE {
+  auto get_ring = pbbslib::make_sequence<uintE>(n, [&](const size_t& v) -> uintE {
     auto d = dists[v];
     return (d == INT_E_MAX) ? UINT_E_MAX : d;
   });

--- a/benchmarks/KCore/JulienneDBS17/KCore.h
+++ b/benchmarks/KCore/JulienneDBS17/KCore.h
@@ -57,8 +57,7 @@ inline sequence<uintE> KCore(Graph& G, size_t num_buckets = 16) {
       if (deg > k) {
         uintE new_deg = std::max(deg - edgesRemoved, k);
         D[v] = new_deg;
-        uintE bkt = b.get_bucket(new_deg);
-        return wrap(v, bkt);
+        return wrap(v, b.get_bucket(new_deg));
       }
       return Maybe<std::tuple<uintE, uintE> >();
     };
@@ -127,13 +126,13 @@ inline sequence<uintE> KCore_FA(Graph& G,
     finished += active.size();
     k_max = std::max(k_max, bkt.id);
 
-    auto apply_f = [&](const uintE v, uintE& bkt) -> void {
+    auto apply_f = [&](const uintE v, uintE& bkt_to_modify) -> void {
       uintE deg = D[v];
       uintE edgesRemoved = ER[v];
       ER[v] = 0;
       uintE new_deg = std::max(deg - edgesRemoved, k);
       D[v] = new_deg;
-      bkt = b.get_bucket(deg, new_deg);
+      bkt_to_modify = b.get_bucket(deg, new_deg);
     };
 
     auto moved = edgeMapData<uintE>(
@@ -187,8 +186,7 @@ inline pbbslib::dyn_arr<uintE> DegeneracyOrder(Graph& G, size_t num_buckets = 16
       if (deg > k) {
         uintE new_deg = std::max(deg - edgesRemoved, k);
         D[v] = new_deg;
-        uintE bkt = b.get_bucket(new_deg);
-        return wrap(v, bkt);
+        return wrap(v, b.get_bucket(new_deg));
       }
       return Maybe<std::tuple<uintE, uintE> >();
     };

--- a/benchmarks/MaximalMatching/Yoshida/MaximalMatching.cc
+++ b/benchmarks/MaximalMatching/Yoshida/MaximalMatching.cc
@@ -70,6 +70,7 @@ double MaximalMatching_runner(Graph& G, commandLine P) {
   double tt = t.stop();
   std::cout << "### Running Time: " << tt << std::endl;
   print_stats(P, query_cutoff, max_query_length, total_work, fraction_covered, tt);
+  return tt;
 }
 
 generate_symmetric_main(MaximalMatching_runner, false);

--- a/benchmarks/MaximalMatching/Yoshida/MaximalMatching.h
+++ b/benchmarks/MaximalMatching/Yoshida/MaximalMatching.h
@@ -88,7 +88,6 @@ std::pair<mm_status, size_t> mm_query(uintE u, uintE v, Graph& G, size_t work_so
 template <class Graph>
 auto MaximalMatching(Graph& G, size_t query_cutoff) {
   using W = typename Graph::weight_type;
-  using edge = std::tuple<uintE, uintE, W>;
 
   size_t m = G.m;
   size_t n = G.n;

--- a/benchmarks/MinimumSpanningForest/Boruvka/MinimumSpanningForest.h
+++ b/benchmarks/MinimumSpanningForest/Boruvka/MinimumSpanningForest.h
@@ -58,7 +58,7 @@ inline sequence<uintE> Boruvka(edge_array<W>& E, uintE*& vtxs,
                                  uintE*& next_vtxs, M& min_edges, P& parents,
                                  D& exhausted, size_t& n) {
   using ct = cas_type;
-  using edge = std::tuple<uintE, uintE, W>;
+  using Edge = std::tuple<uintE, uintE, W>;
   size_t m = E.non_zeros;
   auto edges = E.E;
   auto less = [](const ct& a, const ct& b) {
@@ -96,7 +96,7 @@ inline sequence<uintE> Boruvka(edge_array<W>& E, uintE*& vtxs,
     min_t.start();
     par_for(0, m, pbbslib::kSequentialForThreshold, [&] (size_t i) {
       uintE e_id = edge_ids[i];
-      const edge& e = edges[e_id];
+      const Edge& e = edges[e_id];
       ct cas_e(e_id, std::get<2>(e));
       pbbslib::write_min(min_edges + std::get<0>(e), cas_e, less);
       pbbslib::write_min(min_edges + std::get<1>(e), cas_e, less);
@@ -173,7 +173,7 @@ inline sequence<uintE> Boruvka(edge_array<W>& E, uintE*& vtxs,
     relab_t.start();
     par_for(0, m, pbbslib::kSequentialForThreshold, [&] (size_t i) {
       size_t e_id = edge_ids[i];
-      edge& e = edges[e_id];
+      Edge& e = edges[e_id];
       uintE u = std::get<0>(e);
       uintE v = std::get<1>(e);
       uintE pu = parents[std::get<0>(e)];
@@ -247,7 +247,7 @@ inline edge_array<W> get_top_k(symmetric_graph<vertex, W>& G, size_t k, pbbslib:
   pbbslib::scan_add_inplace(vertex_offs, pbbslib::fl_scan_inclusive);
 
   auto sample_edges = sequence<edge>(sample_size);
-  auto lte = [&](const size_t& l, const size_t& r) { return l <= r; };
+  auto lte = [&](const size_t& left, const size_t& right) { return left <= right; };
 
   par_for(0, sample_size, pbbslib::kSequentialForThreshold, [&] (size_t i) {
         size_t sample_edge = r.ith_rand(i) % m;
@@ -259,8 +259,8 @@ inline edge_array<W> get_top_k(symmetric_graph<vertex, W>& G, size_t k, pbbslib:
         sample_edges[i] = std::make_tuple(vtx, ngh, wgh);
       });
 
-  auto cmp_by_wgh = [](const edge& l, const edge& r) {
-    return std::get<2>(l) < std::get<2>(r);
+  auto cmp_by_wgh = [](const edge& left, const edge& right) {
+    return std::get<2>(left) < std::get<2>(right);
   };
   pbbslib::sample_sort_inplace(sample_edges.slice(), cmp_by_wgh);
 

--- a/benchmarks/MinimumSpanningForest/PBBSMST/MinimumSpanningForest.h
+++ b/benchmarks/MinimumSpanningForest/PBBSMST/MinimumSpanningForest.h
@@ -98,9 +98,9 @@ inline edge_array<W> get_top_k(symmetric_graph<vertex, W>& G, size_t k, UF& uf,
     exit(0);
     return get_remaining(G, k, uf, r);
   }
-  auto cmp_by_wgh = [](const std::tuple<uint32_t, uintE, intE>& l,
-                       const std::tuple<uintE, uintE, intE>& r) {
-    return std::get<2>(l) < std::get<2>(r);
+  auto cmp_by_wgh = [](const std::tuple<uint32_t, uintE, intE>& left,
+                       const std::tuple<uintE, uintE, intE>& right) {
+    return std::get<2>(left) < std::get<2>(right);
   };
   pbbslib::sample_sort(pbbslib::make_sequence(sampled_e.E, sampled_e.non_zeros), cmp_by_wgh);
 
@@ -147,9 +147,9 @@ inline void MinimumSpanningForest(symmetric_graph<vertex, W>& GA) {
     get_t.stop();
     get_t.reportTotal("get time");
     size_t n_edges = edges.non_zeros;
-    auto cmp_by_wgh = [](const std::tuple<uint32_t, uintE, W>& l,
-                         const std::tuple<uintE, uintE, W>& r) {
-      return std::get<2>(l) < std::get<2>(r);
+    auto cmp_by_wgh = [](const std::tuple<uint32_t, uintE, W>& left,
+                         const std::tuple<uintE, uintE, W>& right) {
+      return std::get<2>(left) < std::get<2>(right);
     };
     pbbslib::sample_sort(pbbslib::make_sequence(edges.E, n_edges), cmp_by_wgh);
     std::cout << "Prefix size = " << split_idx << " #edges = " << n_edges

--- a/benchmarks/PositiveWeightSSSP/DeltaStepping/DeltaStepping.h
+++ b/benchmarks/PositiveWeightSSSP/DeltaStepping/DeltaStepping.h
@@ -72,9 +72,9 @@ void DeltaStepping(Graph& G, uintE src, uintE delta, size_t num_buckets=128) {
   auto dists = pbbs::sequence<uintE>(n, [&] (size_t i) { return INT_E_MAX; });
   dists[src] = 0;
 
-  auto get_bkt = [&] (const uintE& dist) -> const uintE {
+  auto get_bkt = [&] (const uintE& dist) -> uintE {
     return (dist == INT_E_MAX) ? UINT_E_MAX : (dist / delta); };
-  auto get_ring = pbbslib::make_sequence<uintE>(n, [&] (const size_t& v) -> const uintE {
+  auto get_ring = pbbslib::make_sequence<uintE>(n, [&] (const size_t& v) -> uintE {
     auto d = dists[v];
     return (d == INT_E_MAX) ? UINT_E_MAX : (d / delta); });
   auto b = make_vertex_buckets(n, get_ring, increasing, num_buckets);

--- a/benchmarks/SSWidestPath/JulienneDBS17/SSWidestPath.h
+++ b/benchmarks/SSWidestPath/JulienneDBS17/SSWidestPath.h
@@ -97,10 +97,10 @@ inline sequence<uintE> SSWidestPath(Graph& G, uintE src,
   auto width = sequence<uintE>(n, [&](size_t i) { return (uintE)0; });
   width[src] = INT_E_MAX;
 
-  auto get_bkt = [&](const W& width) -> const uintE {
-    return max_weight - width + 1;
+  auto get_bkt = [&](const W& _width) -> uintE {
+    return max_weight - _width + 1;
   };
-  auto get_ring = pbbslib::make_sequence<uintE>(n, [&](const size_t& v) -> const uintE {
+  auto get_ring = pbbslib::make_sequence<uintE>(n, [&](const size_t& v) -> uintE {
     auto d = width[v];
     if (d == 0) { return UINT_E_MAX; }
     if (d == INT_E_MAX) { return 0; }

--- a/benchmarks/StronglyConnectedComponents/RandomGreedyBGSS16/StronglyConnectedComponents.h
+++ b/benchmarks/StronglyConnectedComponents/RandomGreedyBGSS16/StronglyConnectedComponents.h
@@ -63,9 +63,11 @@ struct Search_F {
       auto s_iter = tab.get_iter(s);
       // iterate through s's labels.
       if (s_iter.init()) {
-        auto table_entry = s_iter.next();
-        uintE s_label = std::get<1>(table_entry);
-        labels_changed |= tab.insert(std::make_tuple(d, s_label));
+        {
+          auto table_entry = s_iter.next();
+          uintE s_label = std::get<1>(table_entry);
+          labels_changed |= tab.insert(std::make_tuple(d, s_label));
+        }
 
         while (s_iter.has_next()) {
           auto table_entry = s_iter.next();

--- a/benchmarks/TriangleCounting/ShunTangwongsan15/Triangle.h
+++ b/benchmarks/TriangleCounting/ShunTangwongsan15/Triangle.h
@@ -215,21 +215,21 @@ inline size_t Triangle(Graph& G, const F& f, const std::string& ordering, comman
     return Triangle_degree_ordering<Graph, F>(G, f);
   } else if (ordering == "goodrich") {
     auto eps = P.getOptionDoubleValue("-e", 0.1);
-    auto ff = [&] (Graph& G) -> pbbs::sequence<uintE> {
-      return goodrichpszona_degen::DegeneracyOrder_intsort(G, eps);
+    auto ff = [&] (Graph& graph) -> pbbs::sequence<uintE> {
+      return goodrichpszona_degen::DegeneracyOrder_intsort(graph, eps);
     };
     return Triangle_degeneracy_ordering<Graph, F>(G, f, ff);
   } else if (ordering == "kcore") {
-    auto ff = [&] (Graph& G) -> pbbs::sequence<uintE> {
-      auto dyn_arr = DegeneracyOrder(G);
+    auto ff = [&] (Graph& graph) -> pbbs::sequence<uintE> {
+      auto dyn_arr = DegeneracyOrder(graph);
       auto arr = dyn_arr.A; dyn_arr.A = nullptr;
       dyn_arr.alloc = false;
-      return pbbs::sequence<uintE>(arr, G.n);
+      return pbbs::sequence<uintE>(arr, graph.n);
     };
     return Triangle_degeneracy_ordering<Graph, F>(G, f, ff);
   } else if (ordering == "barenboimelkin") {
-    auto ff = [&] (Graph& G) -> pbbs::sequence<uintE> {
-      return barenboimelkin_degen::DegeneracyOrder(G);
+    auto ff = [&] (Graph& graph) -> pbbs::sequence<uintE> {
+      return barenboimelkin_degen::DegeneracyOrder(graph);
     };
     return Triangle_degeneracy_ordering<Graph, F>(G, f, ff);
   } else {

--- a/ligra/bucket.h
+++ b/ligra/bucket.h
@@ -298,9 +298,9 @@ struct buckets {
   id_dyn_arr* bkts;
 
   template <class F>
-  inline size_t update_buckets_seq(F& f, size_t n) {
+  inline size_t update_buckets_seq(F& f, size_t k) {
     size_t ne_before = num_elms;
-    for (size_t i = 0; i < n; i++) {
+    for (size_t i = 0; i < k; i++) {
       auto m = f(i);
       bucket_id bkt = std::get<1>(m.t);
       if (m.exists && bkt != null_bkt) {

--- a/ligra/edge_map_blocked.h
+++ b/ligra/edge_map_blocked.h
@@ -124,11 +124,11 @@ inline vertexSubsetData<data> edgeMapBlocked(Graph& G, VS& indices, F& f,
   // 2. Write each block to blocks and scan degree array.
   par_for(0, indices.size(), pbbslib::kSequentialForThreshold, [&](size_t i) {
     size_t vtx_off = vertex_offs[i];
-    size_t num_blocks = vertex_offs[i + 1] - vtx_off;
+    size_t num_vertex_blocks = vertex_offs[i + 1] - vtx_off;
     uintE vtx_id = indices.vtx(i);
     assert(vtx_id < n);
     auto vtx = G.get_vertex(vtx_id);
-    par_for(0, num_blocks, pbbslib::kSequentialForThreshold, [&](size_t j) {
+    par_for(0, num_vertex_blocks, pbbslib::kSequentialForThreshold, [&](size_t j) {
       size_t block_deg = (fl & in_edges)
                              ? vtx.in_block_degree(j)
                              : vtx.out_block_degree(j);
@@ -353,11 +353,11 @@ inline vertexSubsetData<data> edgeMapChunked(Graph& G, VS& indices, F& f,
   // 2. Write each block to blocks and scan degree array.
   par_for(0, indices.size(), pbbslib::kSequentialForThreshold, [&](size_t i) {
     size_t vtx_off = vertex_offs[i];
-    size_t num_blocks = vertex_offs[i + 1] - vtx_off;
+    size_t num_vertex_blocks = vertex_offs[i + 1] - vtx_off;
     uintE vtx_id = indices.vtx(i);
     assert(vtx_id < n);
     auto vtx = G.get_vertex(vtx_id);
-    par_for(0, num_blocks, pbbslib::kSequentialForThreshold, [&](size_t j) {
+    par_for(0, num_vertex_blocks, pbbslib::kSequentialForThreshold, [&](size_t j) {
       size_t block_deg = (fl & in_edges)
                              ? vtx.in_block_degree(j)
                              : vtx.out_block_degree(j);
@@ -433,10 +433,9 @@ inline vertexSubsetData<data> edgeMapChunked(Graph& G, VS& indices, F& f,
 
     parallel_for(0, all_blocks.size(), [&] (size_t block_id) {
       em_data_block* block = all_blocks[block_id];
-      size_t block_size = block->block_size;
       std::tuple<uintE, data>* block_data = (std::tuple<uintE, data>*)block->data;
       size_t block_offset = block_offsets[block_id];
-      for (size_t i=0; i<block_size; i++) {
+      for (size_t i=0; i<block->block_size; i++) {
         out[block_offset + i] = block_data[i];
       }
       // deallocate block to list_alloc

--- a/ligra/encodings/byte_pd_amortized.h
+++ b/ligra/encodings/byte_pd_amortized.h
@@ -290,19 +290,20 @@ struct simple_iter {
       uintE* block_offsets = (uintE*)(edge_start + sizeof(uintE));
       uchar* nghs_start = edge_start + (num_blocks-1)*sizeof(uintE) + sizeof(uintE); // block offs + virtual_degree
 
-      // do first chunk
-      uchar* finger = nghs_start;
-      uintE start_offset = *((uintE*)finger);
-      uintE end_offset = (0 == (num_blocks-1)) ? degree : (*((uintE*)(edge_start+block_offsets[0])));
-      finger += sizeof(uintE);
-
       auto wgh = pbbs::empty();
-      if (start_offset < end_offset) { // at least one edge in this block
-        uintE ngh = eatFirstEdge(finger, source);
-        if (!t(source, ngh, wgh, start_offset)) return;
-        for (size_t edgeID = start_offset+1; edgeID < end_offset; edgeID++) {
-          ngh += eatEdge(finger);
-          if(!t(source, ngh, wgh, edgeID)) return;
+      {  // do first chunk
+        uchar* finger = nghs_start;
+        uintE start_offset = *((uintE*)finger);
+        uintE end_offset = (0 == (num_blocks-1)) ? degree : (*((uintE*)(edge_start+block_offsets[0])));
+        finger += sizeof(uintE);
+
+        if (start_offset < end_offset) { // at least one edge in this block
+          uintE ngh = eatFirstEdge(finger, source);
+          if (!t(source, ngh, wgh, start_offset)) return;
+          for (size_t edgeID = start_offset+1; edgeID < end_offset; edgeID++) {
+            ngh += eatEdge(finger);
+            if(!t(source, ngh, wgh, edgeID)) return;
+          }
         }
       }
       if ((num_blocks > 2) && parallel) {
@@ -428,13 +429,11 @@ inline void decode_block_cond(T t, uchar* edge_start, const uintE& source,
     if (start_offset < end_offset) {  // at least one edge in this block
       uintE ngh = eatFirstEdge(finger, source);
       W wgh = eatWeight<W>(finger);
-      bool ret = t(ngh, wgh, start_offset);
-      if (!ret) return;
+      if (!t(ngh, wgh, start_offset)) return;
       for (size_t edgeID = start_offset + 1; edgeID < end_offset; edgeID++) {
         ngh += eatEdge(finger);
         wgh = eatWeight<W>(finger);
-        bool ret = t(ngh, wgh, edgeID);
-        if (!ret) break;
+        if (!t(ngh, wgh, edgeID)) break;
       }
     }
   }
@@ -520,10 +519,11 @@ inline E map_reduce(uchar* edge_start, const uintE& source, const uintT& degree,
       finger += sizeof(uintE);
 
       if (start_offset < end_offset) {
-        // Eat first edge, which is compressed specially
         uintE ngh = eatFirstEdge(finger, source);
-        W wgh = eatWeight<W>(finger);
-        cur = reduce.f(cur, m(source, ngh, wgh));
+        {  // Eat first edge, which is compressed specially
+          W wgh = eatWeight<W>(finger);
+          cur = reduce.f(cur, m(source, ngh, wgh));
+        }
         for (size_t j = start_offset + 1; j < end_offset; j++) {
           ngh += eatEdge(finger);
           W wgh = eatWeight<W>(finger);
@@ -960,12 +960,12 @@ inline void repack(const uintE& source, const uintE& degree, uchar* edge_start,
       *block_offset = start;
       size_t current_offset = sizeof(uintE);
 
-      auto nw = U[start];
+      auto first_nw = U[start];
       current_offset =
-          compressFirstEdge(finger, current_offset, source, std::get<0>(nw));
+          compressFirstEdge(finger, current_offset, source, std::get<0>(first_nw));
       current_offset =
-          compressWeight<W>(finger, current_offset, std::get<1>(nw));
-      uintE last_ngh = std::get<0>(nw);
+          compressWeight<W>(finger, current_offset, std::get<1>(first_nw));
+      uintE last_ngh = std::get<0>(first_nw);
       for (size_t j = start + 1; j < end; j++) {
         auto nw = U[j];
         uintE difference = std::get<0>(nw) - last_ngh;
@@ -1024,7 +1024,7 @@ inline size_t pack(P& pred, uchar* edge_start, const uintE& source,
       if (pred(source, ngh, wgh)) {
         tmp[ct++] = std::make_tuple(ngh, wgh);
       }
-      for (size_t i = 1; i < block_deg; i++) {
+      for (size_t j = 1; j < block_deg; j++) {
         ngh += eatEdge(finger);
         wgh = eatWeight<W>(finger);
         if (pred(source, ngh, wgh)) {
@@ -1040,15 +1040,15 @@ inline size_t pack(P& pred, uchar* edge_start, const uintE& source,
     // C) Recompress inside this block
     size_t offset = 0;
     if (ct > 0 && ct < block_deg) {
-      uchar* finger =
+      uchar* finger2 =
           (i > 0) ? (edge_start + block_offsets[i - 1]) : nghs_start;
-      uchar* write_finger = finger + sizeof(uintE);
+      uchar* write_finger = finger2 + sizeof(uintE);
       offset =
           compressFirstEdge(write_finger, offset, source, std::get<0>(tmp[0]));
       offset = compressWeight<W>(write_finger, offset, std::get<1>(tmp[0]));
       uintE last_ngh = std::get<0>(tmp[0]);
-      for (size_t i = 1; i < ct; i++) {
-        const auto& e = tmp[i];
+      for (size_t j = 1; j < ct; j++) {
+        const auto& e = tmp[j];
         uintE difference = std::get<0>(e) - last_ngh;
         offset = compressEdge(write_finger, offset, difference);
         offset = compressWeight<W>(write_finger, offset, std::get<1>(e));
@@ -1088,8 +1088,10 @@ inline void decode_block(uchar* finger, std::tuple<uintE, W>* out, size_t start,
                          size_t end, const uintE& source) {
   if (end - start > 0) {
     uintE ngh = eatFirstEdge(finger, source);
-    W wgh = eatWeight<W>(finger);
-    out[start] = std::make_tuple(ngh, wgh);
+    {
+      W wgh = eatWeight<W>(finger);
+      out[start] = std::make_tuple(ngh, wgh);
+    }
     for (size_t i = start + 1; i < end; i++) {
       // Eat the next 'edge', which is a difference, and reconstruct edge.
       ngh += eatEdge(finger);

--- a/ligra/graph.cc
+++ b/ligra/graph.cc
@@ -1,28 +1,28 @@
 #include "graph.h"
 
 std::function<void()> get_deletion_fn(void* a, void* b) {
-  auto df = [&](void* a, void* b) {
-    pbbslib::free_array(a);
-    pbbslib::free_array(b);
+  auto df = [&](void* aa, void* bb) {
+    pbbslib::free_array(aa);
+    pbbslib::free_array(bb);
   };
   return std::bind(df, a, b);
 }
 
 std::function<void()> get_deletion_fn(void* a, void* b, void* c) {
-  auto df = [&](void* a, void* b, void* c) {
-    pbbslib::free_array(a);
-    pbbslib::free_array(b);
-    pbbslib::free_array(c);
+  auto df = [&](void* aa, void* bb, void* cc) {
+    pbbslib::free_array(aa);
+    pbbslib::free_array(bb);
+    pbbslib::free_array(cc);
   };
   return std::bind(df, a, b, c);
 }
 
 std::function<void()> get_deletion_fn(void* a, void* b, void* c, void* d) {
-  auto df = [&](void* a, void* b, void* c, void* d) {
-    pbbslib::free_array(a);
-    pbbslib::free_array(b);
-    pbbslib::free_array(c);
-    pbbslib::free_array(d);
+  auto df = [&](void* aa, void* bb, void* cc, void* dd) {
+    pbbslib::free_array(aa);
+    pbbslib::free_array(bb);
+    pbbslib::free_array(cc);
+    pbbslib::free_array(dd);
   };
   return std::bind(df, a, b, c, d);
 }

--- a/ligra/graph_mutation.h
+++ b/ligra/graph_mutation.h
@@ -50,7 +50,7 @@ inline symmetric_graph<symmetric_vertex, W> filter_graph(symmetric_graph<vertex,
       auto pred_c = [&](const edge& e) {
         return pred(i, std::get<0>(e), std::get<1>(e));
       };
-      auto n_im_f = [&](size_t i) { return nghs[i]; };
+      auto n_im_f = [&](size_t j) { return nghs[j]; };
       auto n_im = pbbslib::make_sequence<edge>(d, n_im_f);
       pbbslib::filter_out(n_im, pbbslib::make_sequence(dir_nghs, d), pred_c, pbbslib::no_flag);
     }

--- a/ligra/histogram.h
+++ b/ligra/histogram.h
@@ -58,30 +58,30 @@ struct get_bucket {
     std::sort(sample, sample + count);
 
     // only keep those with at least three copies
-    int k = 0;
+    int j = 0;
     int c = 0;
     for (size_t i = 1; i < count; i++) {
       if (sample[i] == sample[i - 1]) {
         if (c++ == 1) {
-          sample[k++] = sample[i];
+          sample[j++] = sample[i];
         }
       } else {
         c = 0;
       }
     }
-    return std::make_tuple(sample, k);
+    return std::make_tuple(sample, j);
   }
 
   std::tuple<E, int>* make_hash_table(E* entries, size_t n, size_t table_size,
-                                      size_t table_mask) {
+                                      size_t _table_mask) {
     using ttype = std::tuple<E, int>;
     auto table = pbbslib::new_array_no_init<ttype>(table_size);
     for (size_t i = 0; i < table_size; i++) table[i] = std::make_pair(0, -1);
     size_t n_distinct = 0;
     for (size_t i = 0; i < n; i++) {
-      size_t h = hash32(entries[i]) & table_mask;
+      size_t h = hash32(entries[i]) & _table_mask;
       while (std::get<1>(table[h]) != -1) {
-        h = (h + 1) & table_mask;
+        h = (h + 1) & _table_mask;
       }
       table[h] = std::make_pair(entries[i], n_distinct++);
     }
@@ -263,8 +263,8 @@ inline std::pair<size_t, O*> histogram_medium(A& get_key, size_t n,
             ct = counts[j * num_buckets + i + 1] - off;
           }
           off += start;
-          for (size_t k = 0; k < ct; k++) {
-            K a = elms[off + k];
+          for (size_t l = 0; l < ct; l++) {
+            K a = elms[off + l];
             S.insertAdd(a);
           }
         }
@@ -464,8 +464,8 @@ inline std::pair<size_t, O*> histogram(A& get_key, size_t n, Apply& apply_f,
               ct = counts[j * num_total_buckets + i + 1] - off;
             }
             off += start;
-            for (size_t k = 0; k < ct; k++) {
-              K a = elms[off + k];
+            for (size_t l = 0; l < ct; l++) {
+              K a = elms[off + l];
               S.insertAdd(a);
             }
           }
@@ -693,8 +693,8 @@ inline std::pair<size_t, O*> histogram_reduce(A& get_elm, B& get_key, size_t n,
             ct = counts[j * num_buckets + i + 1] - off;
           }
           off += start;
-          for (size_t k = 0; k < ct; k++) {
-            E a = elms[off + k];
+          for (size_t l = 0; l < ct; l++) {
+            E a = elms[off + l];
             reduce_f(S, a);
           }
         }

--- a/ligra/speculative_for.h
+++ b/ligra/speculative_for.h
@@ -34,7 +34,7 @@
     intT r;
     reservation() : r(std::numeric_limits<intT>::max()) {}
     void reserve(intT i) {
-      pbbslib::write_min(&r, i, [](intT l, intT r) { return l < r; });
+      pbbslib::write_min(&r, i, [](intT left, intT right) { return left < right; });
     }
     bool reserved() { return (r < std::numeric_limits<intT>::max()); }
     void reset() { r = std::numeric_limits<intT>::max(); }

--- a/pbbslib/README.md
+++ b/pbbslib/README.md
@@ -35,7 +35,7 @@ template library.   However none of them mutate
 their arguments, but rather are copy based.
 
   - all_of, any_of, none_of, count, count_if
-  - find, find_if, find_if_not, find_first_of, find_end, search
+  - find, find_if, find_if_not, find_end, search
   - mismatch, adjacent_find
   - equal, lexicographical_compare,
   - unique, remove_if

--- a/pbbslib/bucket_sort.h
+++ b/pbbslib/bucket_sort.h
@@ -97,12 +97,12 @@ void bucket_sort_r(range<T*> in, range<T*> out, binOp f, bool stable,
   if (n < num_buckets * 32) {
     base_sort(in, out, f, stable, inplace);
   } else {
-    size_t counts[num_buckets];
     sequence<uchar> bucketsm(n);
     uchar* buckets = bucketsm.begin();
     if (get_buckets(in, buckets, f, bits)) {
       base_sort(in, out, f, stable, inplace);
     } else {
+      size_t* counts = new_array_no_init<size_t>(num_buckets);
       radix_step_(in.begin(), out.begin(), buckets, counts, n, num_buckets);
       parallel_for(0, num_buckets,
                    [&](size_t j) {
@@ -112,6 +112,7 @@ void bucket_sort_r(range<T*> in, range<T*> out, binOp f, bool stable,
                                    f, stable, !inplace);
                    },
                    4);
+      free_array(counts);
     }
   }
 }

--- a/pbbslib/collect_reduce.h
+++ b/pbbslib/collect_reduce.h
@@ -264,9 +264,9 @@ auto collect_reduce(Seq const &A, Key const &get_key, Value const &get_value,
 
                  // small blocks have indices in bottom half
                  if (i < cut)
-                   for (size_t i = start; i < end; i++) {
-                     size_t j = get_key(B[i]);
-                     sums[j] = monoid.f(sums[j], get_value(B[i]));
+                   for (size_t j = start; j < end; j++) {
+                     size_t k = get_key(B[j]);
+                     sums[k] = monoid.f(sums[k], get_value(B[j]));
                    }
 
                  // large blocks have indices in top half
@@ -400,8 +400,8 @@ sequence<typename Seq::value_type> collect_reduce_sparse(Seq const &A,
 
         // pack tables down to bottom
         size_t j = 0;
-        for (size_t i = 0; i < table_size; i++)
-          if (flags[i]) move_uninitialized(my_table[j++], my_table[i]);
+        for (size_t k = 0; k < table_size; k++)
+          if (flags[k]) move_uninitialized(my_table[j++], my_table[k]);
         sizes[i] = j;
 
       },

--- a/pbbslib/collect_reduce.h
+++ b/pbbslib/collect_reduce.h
@@ -150,7 +150,7 @@ struct get_bucket {
   //    the top half [2^{bits-1},2^{bits})
   //    and light items shared into the bottom half [0,2^{bits-1})
   template <typename Seq>
-  get_bucket(Seq const &A, HashEq const &heq, size_t bits) : heq(heq) {
+  get_bucket(Seq const &A, HashEq const &_heq, size_t bits) : heq(_heq) {
     size_t n = A.size();
     size_t low_bits = bits - 1;   // for the bottom half
     num_buckets = 1 << low_bits;  // in bottom half
@@ -209,7 +209,7 @@ struct get_bucket {
 template <typename E, typename Key>
 struct hasheq_mask_low {
   Key get_key;
-  hasheq_mask_low(Key get_key) : get_key(get_key) {}
+  hasheq_mask_low(Key _get_key) : get_key(_get_key) {}
   inline size_t hash(E a) const { return hash64_2(get_key(a) & ~((size_t)15)); }
   inline bool eql(E a, E b) const { return get_key(a) == get_key(b); }
 };
@@ -271,8 +271,8 @@ auto collect_reduce(Seq const &A, Key const &get_key, Value const &get_value,
 
                  // large blocks have indices in top half
                  else if (end > start) {
-                   auto x = [&](size_t i) -> val_type {
-                     return get_value(B[i]);
+                   auto x = [&](size_t j) -> val_type {
+                     return get_value(B[j]);
                    };
                    auto vals = delayed_seq<val_type>(n, x);
                    sums[get_key(B[i])] = reduce(vals, monoid);
@@ -387,8 +387,8 @@ sequence<typename Seq::value_type> collect_reduce_sparse(Seq const &A,
           size_t start_l = bucket_offsets[num_tables + i];
           size_t len = bucket_offsets[num_tables + i + 1] - start_l;
           if (len > 0) {
-            auto f = [&](size_t i) -> val_type {
-              return B[i + start_l].second;
+            auto f = [&](size_t j) -> val_type {
+              return B[j + start_l].second;
             };
             auto s = delayed_seq<val_type>(len, f);
             val_type x = reduce(s, monoid);

--- a/pbbslib/get_time.cc
+++ b/pbbslib/get_time.cc
@@ -3,8 +3,8 @@
 #include <iomanip>
 #include <iostream>
 
-timer::timer(std::string name, bool _start)
-    : total_time(0.0), on(false), name(std::move(name)), tzp({0, 0}) {
+timer::timer(std::string _name, bool _start)
+    : total_time(0.0), on(false), name(std::move(_name)), tzp({0, 0}) {
   if (_start) start();
 }
 

--- a/pbbslib/histogram.h
+++ b/pbbslib/histogram.h
@@ -110,7 +110,7 @@ struct get_bucket_old {
   //    the top half [2^{bits-1},2^{bits})
   //    and light items shared into the bottom half [0,2^{bits-1})
   template <typename Seq>
-  get_bucket_old(Seq const &A, HashEq const &heq, size_t bits) : heq(heq) {
+  get_bucket_old(Seq const &A, HashEq const &_heq, size_t bits) : heq(_heq) {
     size_t n = A.size();
     size_t low_bits = bits - 1;   // for the bottom half
     num_buckets = 1 << low_bits;  // in bottom half

--- a/pbbslib/monoid.h
+++ b/pbbslib/monoid.h
@@ -16,7 +16,7 @@ struct monoid {
   using T = TT;
   F f;
   TT identity;
-  monoid(F f, TT id) : f(f), identity(id) {}
+  monoid(F _f, TT id) : f(_f), identity(id) {}
 };
 
 template <class F, class T>

--- a/pbbslib/range_min.h
+++ b/pbbslib/range_min.h
@@ -40,8 +40,8 @@ namespace pbbs {
 template <class Seq, class Compare, class Uint = uint>
 class range_min {
  public:
-  range_min(Seq &a, Compare less, long block_size = 32)
-      : a(a), less(less), n(a.size()), block_size(block_size) {
+  range_min(Seq &_a, Compare _less, long work_block_size = 32)
+      : a(_a), less(_less), n(a.size()), block_size(work_block_size) {
     m = 1 + (n - 1) / block_size;
     precomputeQueries();
   }

--- a/pbbslib/scheduler.h
+++ b/pbbslib/scheduler.h
@@ -140,7 +140,6 @@ struct Deque {
 template <typename Job>
 struct scheduler {
  public:
-  // see comments under wait(..)
   int num_threads;
 
   static thread_local int thread_id;

--- a/pbbslib/scheduler.h
+++ b/pbbslib/scheduler.h
@@ -141,7 +141,6 @@ template <typename Job>
 struct scheduler {
  public:
   // see comments under wait(..)
-  static bool const conservative = false;
   int num_threads;
 
   static thread_local int thread_id;

--- a/pbbslib/seq.h
+++ b/pbbslib/seq.h
@@ -34,7 +34,7 @@ struct range {
   using value_type = typename std::iterator_traits<Iterator>::value_type;
   using iterator = Iterator;
   range(){};
-  range(iterator s, iterator e) : s(s), e(e){};
+  range(iterator _s, iterator _e) : s(_s), e(_e){};
   value_type& operator[](const size_t i) const { return s[i]; }
   range slice(size_t ss, size_t ee) const { return range(s + ss, s + ee); }
   range slice() const { return range(s, e); };
@@ -66,7 +66,7 @@ struct delayed_sequence {
   delayed_sequence(size_t n, F _f) : f(_f), s(0), e(n){};
   delayed_sequence(size_t n, value_type v)
       : f([&](size_t i) { return v; }), s(0), e(n){};
-  delayed_sequence(size_t s, size_t e, F _f) : f(_f), s(s), e(e){};
+  delayed_sequence(size_t _s, size_t _e, F _f) : f(_f), s(_s), e(_e){};
   const value_type operator[](size_t i) const { return (f)(i + s); }
   delayed_sequence<T, F> slice(size_t ss, size_t ee) const {
     return delayed_sequence<T, F>(s + ss, s + ee, f);
@@ -135,15 +135,15 @@ struct sequence {
     return *this;
   }
 
-  sequence(const size_t n)
-      : s(pbbs::new_array<T>(n)),
-        n(n){
+  sequence(const size_t _n)
+      : s(pbbs::new_array<T>(_n)),
+        n(_n){
             // if (n > 1000000000) cout << "make empty: " << s << endl;
         };
 
-  sequence(value_type* a, const size_t n)
+  sequence(value_type* a, const size_t _n)
       : s(a),
-        n(n){
+        n(_n){
             // cout << "dangerous" << endl;
         };
 
@@ -155,15 +155,15 @@ struct sequence {
     return r;
   };
 
-  sequence(const size_t n, value_type v)
-      : s(pbbs::new_array_no_init<T>(n, true)), n(n) {
+  sequence(const size_t _n, value_type v)
+      : s(pbbs::new_array_no_init<T>(_n, true)), n(_n) {
     // if (n > 1000000000) cout << "make const: " << s << endl;
     auto f = [=](size_t i) { new ((void*)(s + i)) value_type(v); };
     parallel_for(0, n, f);
   };
 
   template <typename Func>
-  sequence(const size_t n, Func f) : s(pbbs::new_array_no_init<T>(n)), n(n) {
+  sequence(const size_t _n, Func f) : s(pbbs::new_array_no_init<T>(_n)), n(_n) {
     // if (n > 1000000000) cout << "make func: " << s << endl;
     parallel_for(0, n, [&](size_t i) { new ((void*)(s + i)) value_type(f(i)); },
                  1000);

--- a/pbbslib/stlalgs.h
+++ b/pbbslib/stlalgs.h
@@ -77,17 +77,6 @@ size_t find_if_not(Seq const &S, UnaryPred p) {
   return find_if_index(S.size(), [&](size_t i) { return !p(S[i]); });
 }
 
-template <class Seq1, class Seq2, class BinaryPred>
-size_t find_first_of(Seq1 const &S1, Seq2 const &S2, BinaryPred p) {
-  auto f = [&](size_t i) {
-    size_t j;
-    for (size_t j; j < S2.size(); j++)
-      if (p(S1[i], S2[j])) break;
-    return (j < S2.size());
-  };
-  return find_if_index(S1.size(), f);
-}
-
 template <class Seq, class BinaryPred>
 size_t adjacent_find(Seq const &S, BinaryPred pred) {
   return find_if_index(S.size() - 1,

--- a/pbbslib/stlalgs.h
+++ b/pbbslib/stlalgs.h
@@ -16,15 +16,17 @@ size_t count_if_index(size_t n, IntegerPred p) {
 
 template <class IntegerPred>
 size_t find_if_index(size_t n, IntegerPred p, size_t granularity = 1000) {
-  size_t i;
-  for (i = 0; i < std::min(granularity, n); i++)
-    if (p(i)) return i;
-  if (i == n) return n;
+  {
+    size_t i;
+    for (i = 0; i < std::min(granularity, n); i++)
+      if (p(i)) return i;
+    if (i == n) return n;
+  }
   size_t start = granularity;
   while (start < n) {
     size_t end = std::min(n, start + granularity);
     auto f = [&](size_t i) -> size_t { return p(i + start) ? i + start : n; };
-    i = pbbs::reduce(delayed_seq<size_t>(end - start, f), minm<size_t>());
+    size_t i = pbbs::reduce(delayed_seq<size_t>(end - start, f), minm<size_t>());
     if (i < n) return i;
     start += granularity;
     granularity *= 2;

--- a/pbbslib/time_operations.h
+++ b/pbbslib/time_operations.h
@@ -193,7 +193,7 @@ bool check_histogram(pbbs::sequence<T> const &in,
                      pbbs::sequence<T> const &out) {
   size_t m = out.size();
   auto a = sort(in, std::less<T>());
-  auto b = get_counts(a, [&](T a) { return a; }, m);
+  auto b = get_counts(a, [&](T x) { return x; }, m);
   size_t err_loc =
       pbbs::find_if_index(m, [&](size_t i) { return out[i] != b[i]; });
   if (err_loc != m) {

--- a/pbbslib/time_tests.cc
+++ b/pbbslib/time_tests.cc
@@ -16,11 +16,7 @@
 #include <limits>
 #include <vector>
 
-size_t str_to_int(char* str) { return strtol(str, NULL, 10); }
-
-void report_time(double t, std::string name) {
-  cout << name << " : " << t << endl;
-}
+namespace {
 
 template <typename F>
 std::vector<double> repeat(size_t n, size_t rounds, bool check, F test) {
@@ -45,7 +41,6 @@ double median(std::vector<double> V) {
     return (V[V.size() / 2] + V[V.size() / 2 - 1]) / 2.0;
 }
 
-double sumf(double a, double b) { return a + b; };
 double minf(double a, double b) { return (a < b) ? a : b; };
 double maxf(double a, double b) { return (a > b) ? a : b; };
 
@@ -204,6 +199,8 @@ double pick_test(size_t id, size_t n, size_t rounds, bool half_length) {
       return 0.0;
   }
 }
+
+}  // namespace
 
 int main(int argc, char* argv[]) {
   commandLine P(argc, argv,


### PR DESCRIPTION
This enables some helpful C++ compiler warnings and adjusts the codebase to not trigger any of these warnings.

Some of the changes in this PR were an attempt to additionally address `-Wshadow` and `-Wmissing-declarations`, but I decided that those flags generated too many warnings to be worth addressing right now. I ended up not including those two flags, though I do think `-Wshadow` is a useful flag to avoid accidental logic errors.