### PR TITLE
pbbslib: Add assertion macros

### DIFF
--- a/ligra/bridge.h
+++ b/ligra/bridge.h
@@ -94,7 +94,6 @@ namespace pbbslib {
   using pbbs::write_min;
   using pbbs::log2_up;
   using pbbs::granularity;
-  using pbbs::assert_str;
 
   template<typename T>
   inline void assign_uninitialized(T& a, const T& b) {

--- a/pbbslib/BUILD
+++ b/pbbslib/BUILD
@@ -307,6 +307,11 @@ cc_library(
   hdrs = ["maybe.h"],
 )
 
+cc_library(
+  name = "assert",
+  hdrs = ["assert.h"],
+)
+
 cc_binary(
   name = "time_tests",
   srcs = ["time_tests.cc"],

--- a/pbbslib/assert.h
+++ b/pbbslib/assert.h
@@ -8,6 +8,16 @@
 #include <iostream>
 
 // Prints out message and terminates the program unconditionally.
+//
+// Usage examples
+// --------------
+// If the program 'foo/bar.cc' hits
+//     ABORT("A bad thing happened");
+// on line 45, then the program will terminate at runtime with the message
+//     foo/bar.cc:45: Abort: A bad thing happened
+// Moreover, to some extent, the input message can be treated like a stream:
+//     int x = 0;
+//     ABORT("Unexpected value of x: " << x);
 #define ABORT(message) \
   do { \
     std::cerr << __FILE__ << ":" << __LINE__ << ": Abort: "  \
@@ -22,10 +32,22 @@
 //
 // Arguments
 // ---------
-//   condition: bool
-//     The condition on which to assert.
-//   (optional) message: string
-//     An explanatory message to print out when the condition fails.
+// condition: bool
+//   The condition on which to assert.
+// (optional) message: string
+//   An explanatory message to print out when the condition fails.
+//
+// Usage examples
+// --------------
+// If the program 'foo/bar.cc' hits
+//     ASSERT(0 == 1, "Expected zero to be equal to one");
+// on line 45, then the program will terminate at runtime with the message
+//     foo/bar.cc:45: Failed assertion `0 < 1`: Expected zero to be equal to one
+// The input message may also be omitted:
+//     ASSERT(0 == 1);
+// Moreover, to some extent, the input message can be treated like a stream:
+//     int x = 0;
+//     ABORT(x > 0, "x must be positive, was " << x << " instead")
 #define ASSERT(...) _GET_MACRO(__VA_ARGS__, _ASSERT2, _ASSERT1)(__VA_ARGS__)
 
 

--- a/pbbslib/assert.h
+++ b/pbbslib/assert.h
@@ -1,7 +1,12 @@
 // Assertion macros.
 //
 // These are implemented as macros instead of functions so that `__FILE__` and
-// `__LINE__` may be used to determine the location of a failing assertion.
+// `__LINE__` may be used to print the location of a failing assertion.
+//
+// These  are more intended for debugging and validating internal programming
+// logic rather than for user errors (e.g., a user who has made an error in
+// specifying input flags to a binary doesn't care about the location of the
+// failing assertion but rather what kind of input flags the binary expects).
 #pragma once
 
 #include <exception>

--- a/pbbslib/assert.h
+++ b/pbbslib/assert.h
@@ -1,0 +1,60 @@
+// Assertion macros.
+//
+// These are implemented as macros instead of functions so that `__FILE__` and
+// `__LINE__` may be used to determine the location of a failing assertion.
+#pragma once
+
+#include <exception>
+#include <iostream>
+
+// Prints out message and terminates the program unconditionally.
+#define ABORT(message) \
+  do { \
+    std::cerr << __FILE__ << ":" << __LINE__ << ": Abort: "  \
+         << message << std::endl; \
+    std::terminate(); \
+  } while (false)
+
+// Asserts on a condition, printing an error and terminating if the condition is
+// false.
+//
+// This is overloaded and can take either one or two arguments.
+//
+// Arguments
+// ---------
+//   condition: bool
+//     The condition on which to assert.
+//   (optional) message: string
+//     An explanatory message to print out when the condition fails.
+#define ASSERT(...) _GET_MACRO(__VA_ARGS__, _ASSERT2, _ASSERT1)(__VA_ARGS__)
+
+
+//////////////
+// Internal //
+//////////////
+
+// Trickery from https://stackoverflow.com/a/11763277/4865149 to support
+// overloading macros by number of arguments.
+// If we need to do this kind of overloading more often, consider
+// importing Boost and replacing this macro with BOOST_PP_OVERLOAD.
+#define _GET_MACRO(_1,_2,NAME,...) NAME
+
+// Implementation of ASSERT with one argument.
+#define _ASSERT1(condition) \
+  do { \
+    if (!(condition)) { \
+      std::cerr << __FILE__ << ":" << __LINE__ << ": Failed assertion `"  \
+          #condition "`" << std::endl; \
+      std::terminate(); \
+    } \
+  } while (false)
+
+// Implementation of ASSERT with two arguments.
+#define _ASSERT2(condition, message) \
+  do { \
+    if (!(condition)) { \
+      std::cerr << __FILE__ << ":" << __LINE__ << ": Failed assertion `"  \
+          #condition "`: " << message << std::endl; \
+      std::terminate(); \
+    } \
+  } while (false)

--- a/pbbslib/assert.h
+++ b/pbbslib/assert.h
@@ -2,11 +2,6 @@
 //
 // These are implemented as macros instead of functions so that `__FILE__` and
 // `__LINE__` may be used to print the location of a failing assertion.
-//
-// These  are more intended for debugging and validating internal programming
-// logic rather than for user errors (e.g., a user who has made an error in
-// specifying input flags to a binary doesn't care about the location of the
-// failing assertion but rather what kind of input flags the binary expects).
 #pragma once
 
 #include <exception>
@@ -33,6 +28,10 @@
 // Asserts on a condition, printing an error and terminating if the condition is
 // false.
 //
+// This is more intended for debugging and validating internal programming logic
+// than for detecting user errors. We may choose to replace `ASSERT` with a
+// no-op in optimized builds.
+//
 // This is overloaded and can take either one or two arguments.
 //
 // Arguments
@@ -45,9 +44,9 @@
 // Usage examples
 // --------------
 // If the program 'foo/bar.cc' hits
-//     ASSERT(0 == 1, "Expected zero to be equal to one");
+//     ASSERT(0 == 1, "Zero should be equal to one");
 // on line 45, then the program will terminate at runtime with the message
-//     foo/bar.cc:45: Failed assertion `0 < 1`: Expected zero to be equal to one
+//     foo/bar.cc:45: Failed assertion `0 == 1`: Zero should be equal to one
 // The input message may also be omitted:
 //     ASSERT(0 == 1);
 // Moreover, to some extent, the input message can be treated like a stream:

--- a/pbbslib/assert.h
+++ b/pbbslib/assert.h
@@ -52,7 +52,7 @@
 //     ASSERT(0 == 1);
 // Moreover, to some extent, the input message can be treated like a stream:
 //     int x = 0;
-//     ABORT(x > 0, "x must be positive, was " << x << " instead")
+//     ABORT(x > 0, "x must be positive, was " << x << " instead");
 #define ASSERT(...) _GET_MACRO(__VA_ARGS__, _ASSERT2, _ASSERT1)(__VA_ARGS__)
 
 

--- a/pbbslib/utilities.cc
+++ b/pbbslib/utilities.cc
@@ -17,10 +17,4 @@ void free_array(void* a) { my_free(a); }
 
 size_t granularity(size_t n) { return (n > 100) ? ceil(pow(n, 0.5)) : 100; }
 
-void assert_str(int cond, const std::string& s) {
-  if (!cond) {
-    std::cout << "PBBS assert error: " << s << std::endl;
-  }
-}
-
 }  // namespace pbbs

--- a/pbbslib/utilities.h
+++ b/pbbslib/utilities.h
@@ -350,6 +350,3 @@ size_t log2_up(T i) {
 }
 
 size_t granularity(size_t n);
-
-void assert_str(int cond, const std::string& s);
-}

--- a/pbbslib/utilities.h
+++ b/pbbslib/utilities.h
@@ -350,3 +350,5 @@ size_t log2_up(T i) {
 }
 
 size_t granularity(size_t n);
+
+}  // namespace pbbs


### PR DESCRIPTION
This PR adds some macros that are useful for validating internal programming logic when debugging.

I put these macros in `pbbslib/`, though I'm not so sure that's the appropriate place to put them since they're not a part of the `PBBS` codebase...

Macros:
- `ASSERT()`: the benefit of this over the C `assert()` is that an optional message can be provided, e.g., 
```cpp
int x = 0;
ABORT(x > 0, "x must be positive, was " << x << " instead");
```
on lines 44-45 of `foo/bar.cc` will print
```
foo/bar.cc:45: Failed assertion `x > 0`: x must be positive, was 0 instead
```
- `ABORT()`: takes a message as argument; the benefit of this is that `ABORT("unexpected value of x")` is more concise than always typing `std::cerr << "unexpected value of x\n"; abort()` every time we want to quit the program.

Currently, unlike `assert()`, `ASSERT()` is not removed by setting the `NDEBUG` macro, though we can change that if desired.