### PR TITLE
bazelrc: Add config options for compiling serially or with Cilk or OpenMP

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,7 +18,7 @@ test --test_strategy=standalone
 # package path.
 
 
-# By default build in C++17 mode.
+# By default build in C++17 mode using the Homegrown scheduler for parallelism.
 build --cxxopt=-std=c++17
 build --cxxopt=-mcx16        # 16 byte CAS
 build --cxxopt=-DHOMEGROWN   # use the homegrown scheduler
@@ -37,6 +37,21 @@ build --cxxopt=-Wpointer-arith
 # codebase currently contains lots of instances of global shadowing.
 build --cxxopt=-Wshadow=local
 build --cxxopt=-Wvla
+
+# Build without parallelism.
+build:serial --cxxopt=-UHOMEGROWN
+
+# Build using CilkPlus for parallelism.
+build:cilk --cxxopt=-UHOMEGROWN
+build:cilk --cxxopt=-DCILK
+build:cilk --cxxopt=-fcilkplus
+build:cilk --linkopt=-lcilkrts
+
+# Build using OpenMP for parallelism.
+build:openmp --cxxopt=-UHOMEGROWN
+build:openmp --cxxopt=-DOPENMP
+build:openmp --cxxopt=-fopenmp
+build:openmp --linkopt=-fopenmp
 
 # Instruments the build with AddressSanitizer
 # (https://github.com/google/sanitizers/wiki/AddressSanitizer).

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Compilation
 * g++ &gt;= 5.3.0 with support for Cilk Plus
 * g++ &gt;= 5.3.0 with pthread support (Homemade Scheduler)
 
-The default compilation uses Cilk Plus. We also support a lightweight scheduler
-developed at CMU (Homemade), which results in comparable performance to Cilk.
-The half-lengths for certain functions such as histogramming are lower using
+The default compilation uses a lightweight scheduler developed at CMU (Homemade)
+for parallelism, which results in comparable performance to Cilk Plus. The
+half-lengths for certain functions such as histogramming are lower using
 Homemade, which results in better performance for codes like KCore.
 
 Note: The Homemade scheduler was developed after our paper submission. For
@@ -88,8 +88,10 @@ parameter should be set. If the graph has more than 2^32 vertices, the
 been tested with more than 2^32 vertices, so if any issues arise please contact
 [Laxman Dhulipala](mailto:ldhulipa@cs.cmu.edu).
 
-To compile using the Homemade scheduler the `HOMEMADE` command-line parameter
-should be set. If it is unset, the Cilk Plus scheduler is used by default.
+To compile with the Cilk Plus scheduler instead of the Homegrown scheduler, use
+the Bazel configuration `--config=cilk`. To compile using OpenMP instead, use
+the Bazel configuration `--config=openmp`. To compile serially instead, use the
+Bazel configuration `--config=serial`.
 
 After setting the necessary environment variables:
 ```

--- a/pbbslib/parallel.cc
+++ b/pbbslib/parallel.cc
@@ -16,6 +16,8 @@ void set_num_workers(int n) {
 
 #elif defined(OPENMP)
 
+bool in_par_do = false;
+
 int num_workers() { return omp_get_max_threads(); }
 int worker_id() { return omp_get_thread_num(); }
 void set_num_workers(int n) { omp_set_num_threads(n); }

--- a/pbbslib/parallel.h
+++ b/pbbslib/parallel.h
@@ -109,7 +109,10 @@ inline void parallel_for_alloc(Af init_alloc, Df finish_alloc, long start,
 // openmp
 #elif defined(OPENMP)
 #include <omp.h>
+#include <stddef.h>
 #define PAR_GRANULARITY 200000
+
+extern bool in_par_do;
 
 template <class F>
 inline void parallel_for(long start, long end, F f, long granularity,
@@ -123,8 +126,6 @@ inline void parallel_for_1(long start, long end, F f, long granularity,
 #pragma omp for schedule(dynamic, 1) nowait
   for (long i = start; i < end; i++) f(i);
 }
-
-bool in_par_do = false;
 
 template <typename Lf, typename Rf>
 inline void par_do(Lf left, Rf right, bool conservative) {


### PR DESCRIPTION
In PR #6, I broke all the makefiles by moving function definitions out of header files into new implementation files. I didn't realize this.

Now that all the makefiles are broken, we need a way to compile with Cilk with Bazel, as @yushangdi pointed out. This PR adds a way to compile with Cilk, OpenMP, or serially through Bazel.