### PR TITLE
graph: bugfix for degree calculation in sym_graph_from_edges

### DIFF
--- a/ligra/graph.h
+++ b/ligra/graph.h
@@ -392,7 +392,9 @@ inline symmetric_graph<symmetric_vertex, W> sym_graph_from_edges(
       }
     }
     if (i == (m-1)) { /* last edge */
-      starts[get_u(A[i]) + 1] = m;
+      par_for(get_u(A[i]) + 1, starts.size(), [&](size_t j) {
+        starts[j] = m;
+      });
     }
     return std::make_tuple(get_v(A[i]), get_w(A[i]));
   });

--- a/ligra/unit_tests/graph_test.cc
+++ b/ligra/unit_tests/graph_test.cc
@@ -32,3 +32,20 @@ TEST(TestSymGraphFromEdges, TestBrokenPath) {
   ASSERT_EQ(G.get_vertex(9).getOutDegree(), 2);
   ASSERT_EQ(G.get_vertex(10).getOutDegree(), 3);
 }
+
+TEST(TestSymGraphFromEdges, TestGraphWithSingletons) {
+  // Graph diagram:
+  // 0 -- 1    2    3
+  using edge = std::tuple<uintE, uintE, int>;
+  const uintE n = 4;
+  pbbs::sequence<edge> edges(2);
+  edges[0] = std::make_tuple(0, 1, 1);
+  edges[1] = std::make_tuple(1, 0, 1);
+  auto graph = sym_graph_from_edges(edges, n);
+
+  ASSERT_EQ(graph.n, n);
+  ASSERT_EQ(graph.get_vertex(0).getOutDegree(), 1);
+  ASSERT_EQ(graph.get_vertex(1).getOutDegree(), 1);
+  ASSERT_EQ(graph.get_vertex(2).getOutDegree(), 0);
+  ASSERT_EQ(graph.get_vertex(3).getOutDegree(), 0);
+}


### PR DESCRIPTION
## PR

I encountered a bug in `sym_graph_from_edges`. This PR adds a fix and adds unit test that failed prior to the fix.

## Bug description

Consider the following graph:
```
0 -- 1    2    3
```
We construct this graph by giving the directed edges `(0, 1), (1,0)` and the number of vertices `4` to `sym_graph_from_edges`.

Now `sym_graph_from_edges` sorts the edges by the first endpoint and computes an array `starts` such that, in rough terms, `starts[i]` represents the point where vertex `i` appears as a first endpoint in the edge list. We expect `starts` to be a non-decreasing sequence since the edges are sorted.
Then by computing the differences between consecutive `starts` entries, we get the degrees of each vertex.

However, in the case where some vertices don't have any edges, the last few entries of `starts[i]` were not being populated correctly. Prior to the bugfix, `starts` was `[0, 1, 2, 0, 0]` for the above graph, so then the degree of vertex 2 was computed to be `starts[3] - starts[2]` which is something like `INT_MAX - 1` due to overflow. We should have `starts` be `[0, 1, 2, 2, 2]` instead.