### PR TITLE
ligra: Clean up list_allocator at the end of Ligra generated main

### DIFF
--- a/ligra/BUILD
+++ b/ligra/BUILD
@@ -61,6 +61,7 @@ cc_library(
 cc_library(
   name = "edge_map_blocked",
   hdrs = ["edge_map_blocked.h"],
+  srcs = ["edge_map_blocked.cc"],
   deps = [
   ":bridge",
   ":edge_map_utils",

--- a/ligra/edge_map_blocked.cc
+++ b/ligra/edge_map_blocked.cc
@@ -1,0 +1,5 @@
+#include "ligra/edge_map_blocked.h"
+
+void alloc_finish() {
+  data_block_allocator::finish();
+}

--- a/ligra/edge_map_blocked.h
+++ b/ligra/edge_map_blocked.h
@@ -322,6 +322,9 @@ void alloc_init(Graph& G) {
   data_block_allocator::print_stats();
 }
 
+// Call this to clean up at the end of a program that invokes `alloc_init`.
+void alloc_finish();
+
 template <class data  /* data associated with vertices in the output vertex_subset */,
           class Graph /* graph type */,
           class VS    /* vertex_subset type */,

--- a/ligra/ligra.h
+++ b/ligra/ligra.h
@@ -405,6 +405,7 @@ inline auto get_pcm_state() { return (size_t)1; }
         run_app(G_coo, APP, rounds)                                            \
       }                                                                        \
     }                                                                          \
+    alloc_finish();                                                            \
   }
 
 /* Macro to generate binary for graph applications that read a graph (either
@@ -451,6 +452,7 @@ inline auto get_pcm_state() { return (size_t)1; }
         run_app(G_coo, APP, 1)                                                 \
       }                                                                        \
     }                                                                          \
+    alloc_finish();                                                            \
   }
 
 /* Macro to generate binary for unweighted graph applications that can ingest only
@@ -491,6 +493,7 @@ inline auto get_pcm_state() { return (size_t)1; }
         run_app(G, APP, rounds)                                                \
       }                                                                        \
     }                                                                          \
+    alloc_finish();                                                            \
   }
 
 /* Macro to generate binary for unweighted graph applications that can ingest only
@@ -520,6 +523,7 @@ inline auto get_pcm_state() { return (size_t)1; }
         alloc_init(G);                                                         \
         run_app(G, APP, rounds)                                                \
     }                                                                          \
+    alloc_finish();                                                            \
   }
 
 /* Macro to generate binary for unweighted graph applications that can ingest only
@@ -548,6 +552,7 @@ inline auto get_pcm_state() { return (size_t)1; }
         alloc_init(G);                                                         \
         run_app(G, APP, 1)                                                     \
     }                                                                          \
+    alloc_finish();                                                            \
   }
 
 /* Macro to generate binary for weighted graph applications that can ingest
@@ -588,6 +593,7 @@ inline auto get_pcm_state() { return (size_t)1; }
         run_app(G, APP, rounds)                                                \
       }                                                                        \
     }                                                                          \
+    alloc_finish();                                                            \
   }
 
 /* Macro to generate binary for weighted graph applications that can ingest
@@ -615,4 +621,5 @@ inline auto get_pcm_state() { return (size_t)1; }
       alloc_init(G);                                                           \
       run_app(G, APP, rounds)                                                  \
     }                                                                          \
+    alloc_finish();                                                            \
   }


### PR DESCRIPTION
The `generate*_main` macros in `ligra/ligra.h` invoke a `list_allocator` (`pbbslib/list_allocator.h`) but never call `list_allocator::finish()` to clean up at the end. This makes AddressSanitizer report a lot of memory leaks sometimes. This PR adds a clean up call at the end of these `generate*_main` macros.

(AddressSanitizer still reports memory leaks after this --- e.g, in `WorkEfficientSDB14`, it reports leaks regarding the entries in `emhelper::perthread_blocks`. That leak looks harder to debug though since there's trickier logic happening there, so I'm not going to deal with it right now.)