### PR TITLE
README: Update compiler version

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ If you use our work, please cite our [paper](https://arxiv.org/abs/1805.05208):
 Compilation
 --------
 
-* g++ &gt;= 5.3.0 with support for Cilk Plus
-* g++ &gt;= 5.3.0 with pthread support (Homemade Scheduler)
+* g++ &gt;= 7.4.0 with support for Cilk Plus
+* g++ &gt;= 7.4.0 with pthread support (Homemade Scheduler)
 
 The default compilation uses a lightweight scheduler developed at CMU (Homemade)
 for parallelism, which results in comparable performance to Cilk Plus. The


### PR DESCRIPTION
Since CI uses g++ version 7.4.0, that's the only version we can guarantee the code compiles with --- we should update the requirements listed in the README accordingly.

In particular, it turns out the `-Wshadow=local` flag that I added to `.bazelrc` is only available starting in GCC 7.

Unfortunately, Cilk support is also deprecated in GCC 7, and is removed entirely in Cilk GCC 8. An alternative path forward would be to just remove `-Wshadow=local` (ideally we would replace it with the much older flag `-Wshadow`, but our codebase contains too many instances of shadowing right now) and force Travis to use whatever g++ version is ideal for us.