### PR TITLE
ligra: Add comments and unit test regarding bug with vertex intersection

### DIFF
--- a/ligra/BUILD
+++ b/ligra/BUILD
@@ -127,6 +127,7 @@ cc_library(
   ":macros",
   ":undirected_edge",
   ":vertex",
+  "//pbbslib:sample_sort",
   "//pbbslib:utilities",
   ]
 )

--- a/ligra/BUILD
+++ b/ligra/BUILD
@@ -127,6 +127,7 @@ cc_library(
   ":macros",
   ":undirected_edge",
   ":vertex",
+  "//pbbslib:assert",
   "//pbbslib:sample_sort",
   "//pbbslib:utilities",
   ]

--- a/ligra/graph_test_utils.cc
+++ b/ligra/graph_test_utils.cc
@@ -2,6 +2,7 @@
 
 #include <tuple>
 
+#include "pbbslib/assert.h"
 #include "pbbslib/sample_sort.h"
 
 namespace graph_test {
@@ -44,6 +45,7 @@ symmetric_graph<symmetric_vertex, pbbslib::empty> MakeUnweightedSymmetricGraph(
       return sym_graph_from_edges(edge_sequence, num_vertices);
     }
   }
+  ABORT_INVALID_ENUM(ShouldSortNeighbors, should_sort_neighbors);
 }
 
 }  // namespace graph_test

--- a/ligra/graph_test_utils.cc
+++ b/ligra/graph_test_utils.cc
@@ -2,14 +2,18 @@
 
 #include <tuple>
 
+#include "pbbslib/sample_sort.h"
+
 namespace graph_test {
 
 symmetric_graph<symmetric_vertex, pbbslib::empty> MakeUnweightedSymmetricGraph(
     const uintE num_vertices,
-    const std::unordered_set<UndirectedEdge>& edges) {
+    const std::unordered_set<UndirectedEdge>& edges,
+    const ShouldSortNeighbors should_sort_neighbors) {
+  using Edge = std::tuple<uintE, uintE, pbbslib::empty>;
   constexpr pbbs::empty weight{};
-  pbbs::sequence<std::tuple<uintE, uintE, pbbslib::empty>> edge_sequence(
-      edges.size() * 2);
+
+  pbbs::sequence<Edge> edge_sequence(edges.size() * 2);
   auto edges_it{edges.cbegin()};
   for (size_t i = 0; i < edges.size(); i++) {
     edge_sequence[2 * i] =
@@ -24,7 +28,22 @@ symmetric_graph<symmetric_vertex, pbbslib::empty> MakeUnweightedSymmetricGraph(
           weight);
     ++edges_it;
   }
-  return sym_graph_from_edges(edge_sequence, num_vertices);
+
+  switch (should_sort_neighbors) {
+    case ShouldSortNeighbors::kYes: {
+      pbbs::sample_sort_inplace(
+          edge_sequence.slice(),
+          [](const Edge& left, const Edge& right) {
+            return std::tie(std::get<0>(left), std::get<1>(left))
+              < std::tie(std::get<0>(right), std::get<1>(right));
+          });
+      const bool edges_are_sorted{true};
+      return sym_graph_from_edges(edge_sequence, num_vertices, edges_are_sorted);
+    }
+    case ShouldSortNeighbors::kNo: {
+      return sym_graph_from_edges(edge_sequence, num_vertices);
+    }
+  }
 }
 
 }  // namespace graph_test

--- a/ligra/graph_test_utils.h
+++ b/ligra/graph_test_utils.h
@@ -12,9 +12,15 @@
 
 namespace graph_test {
 
+enum class ShouldSortNeighbors { kYes, kNo };
+
 // Make an undirected, unweighted graph from a list of edges.
+//
+// If `should_sort_neighbors` is set to `ShouldSortNeighbors::kYes`, then each
+// vertex's list of neighbors will be sorted in the graph representation.
 symmetric_graph<symmetric_vertex, pbbslib::empty> MakeUnweightedSymmetricGraph(
     const uintE num_vertices,
-    const std::unordered_set<UndirectedEdge>& edges);
+    const std::unordered_set<UndirectedEdge>& edges,
+    ShouldSortNeighbors should_sort_neighbors = ShouldSortNeighbors::kNo);
 
 }  // namespace graph_test

--- a/ligra/unit_tests/BUILD
+++ b/ligra/unit_tests/BUILD
@@ -3,6 +3,7 @@ cc_test(
     srcs = ["graph_test.cc"],
     deps = [
         "//ligra:graph",
+        "//ligra:graph_test_utils",
         "//pbbslib:seq",
         "@googletest//:gtest_main",
     ],

--- a/ligra/unit_tests/graph_test.cc
+++ b/ligra/unit_tests/graph_test.cc
@@ -1,6 +1,9 @@
 #include <gtest/gtest.h>
 #include "ligra/graph.h"
+#include "ligra/graph_test_utils.h"
 #include "pbbslib/seq.h"
+
+namespace gt = graph_test;
 
 TEST(TestSymGraphFromEdges, TestBrokenPath) {
   using edge = std::tuple<uintE, uintE, int>;
@@ -31,4 +34,51 @@ TEST(TestSymGraphFromEdges, TestBrokenPath) {
   ASSERT_EQ(G.get_vertex(8).getOutDegree(), 2);
   ASSERT_EQ(G.get_vertex(9).getOutDegree(), 2);
   ASSERT_EQ(G.get_vertex(10).getOutDegree(), 3);
+}
+
+TEST(symmetric_vertex, Intersect) {
+  using Vertex = symmetric_vertex<pbbs::empty>;
+
+  // Graph diagram:
+  //   0 - 1 - 2
+  //    \ / \ /
+  //     3 - 4 -- 5
+  constexpr uintE kNumVertices{6};
+  const std::unordered_set<UndirectedEdge> kEdges{
+    {0, 1},
+    {0, 3},
+    {1, 2},
+    {1, 3},
+    {1, 4},
+    {2, 4},
+    {3, 4},
+    {4, 5},
+  };
+  auto graph{gt::MakeUnweightedSymmetricGraph(
+      kNumVertices, kEdges, gt::ShouldSortNeighbors::kYes)};
+
+  {
+    const uintE u_id{0};
+    const uintE v_id{5};
+    Vertex u{graph.get_vertex(u_id)};
+    Vertex v{graph.get_vertex(v_id)};
+    EXPECT_EQ((u.intersect(&v, u_id, v_id)), 0);
+    EXPECT_EQ((v.intersect(&u, v_id, u_id)), 0);
+  }
+  {
+    const uintE u_id{0};
+    const uintE v_id{1};
+    Vertex u{graph.get_vertex(u_id)};
+    Vertex v{graph.get_vertex(v_id)};
+    EXPECT_EQ((u.intersect(&v, u_id, v_id)), 1);
+    EXPECT_EQ((v.intersect(&u, v_id, u_id)), 1);
+  }
+  {
+    const uintE u_id{1};
+    const uintE v_id{3};
+    Vertex u{graph.get_vertex(u_id)};
+    Vertex v{graph.get_vertex(v_id)};
+    EXPECT_EQ((u.intersect(&v, u_id, v_id)), 2);
+    EXPECT_EQ((v.intersect(&u, v_id, u_id)), 2);
+  }
 }

--- a/ligra/vertex.h
+++ b/ligra/vertex.h
@@ -26,6 +26,7 @@
 #include "pbbslib/sequence_ops.h"
 #include "macros.h"
 
+// This `intersection` namespace is intended for internal use only.
 namespace intersection {
 
 template <template <typename W> class vertex, class W>
@@ -487,17 +488,37 @@ struct symmetric_vertex {
     return vertex_ops::get_iter(getOutNeighbors(), getOutDegree());
   }
 
+  // Computes the number of neighbors that this vertex and vertex `other`
+  // shares.
+  //
+  // This function will only return correct results if the neighbor lists of
+  // `this` and `other` are both sorted in ascending order. This condition does
+  // not necessarily hold for all graphs.
+  //
+  // `our_id` must be the ID of `this`.
+  // `other` is the vertex to intersect with, and `other_id` must be its ID.
   inline size_t intersect(symmetric_vertex<W>* other, long our_id,
                           long other_id) {
     return intersection::intersect(this, other, our_id, other_id);
   }
 
+  // Same as `intersect`, but runs `f(our_id, other_id, shared_neighbor_id)` for
+  // each shared neighbor between the two vertices.
+  //
+  // This function will only return correct results if the neighbor lists of
+  // `this` and `other` are both sorted in ascending order. This condition does
+  // not necessarily hold for all graphs.
   template <class F>
   inline size_t intersect_f(symmetric_vertex<W>* other, long our_id,
                             long other_id, const F& f) {
     return intersection::intersect_f(this, other, our_id, other_id, f);
   }
 
+  // Parallel version of `intersect_f`.
+  //
+  // This function will only return correct results if the neighbor lists of
+  // `this` and `other` are both sorted in ascending order. This condition does
+  // not necessarily hold for all graphs.
   template <class F>
   inline size_t intersect_f_par(symmetric_vertex<W>* other, long our_id,
                             long other_id, const F& f) {
@@ -752,17 +773,20 @@ struct asymmetric_vertex {
     return vertex_ops::get_iter(getOutNeighbors(), getOutDegree());
   }
 
+  // See comment for `symmetric_vertex::intersect`.
   inline size_t intersect(asymmetric_vertex<W>* other, long our_id,
                           long other_id) {
     return intersection::intersect(this, other, our_id, other_id);
   }
 
+  // See comment for `symmetric_vertex::intersect_f`.
   template <class F>
   inline size_t intersect_f(asymmetric_vertex<W>* other, long our_id,
                             long other_id, const F& f) {
     return intersection::intersect_f(this, other, our_id, other_id, f);
   }
 
+  // See comment for `symmetric_vertex::intersect_f_par`.
   template <class F>
   inline size_t intersect_f_par(asymmetric_vertex<W>* other, long our_id,
                             long other_id, const F& f) {

--- a/pbbslib/assert.h
+++ b/pbbslib/assert.h
@@ -28,7 +28,8 @@
 // Prints out enum value and terminates the program.
 //
 // This is intended for use after a switch statement on an enum that handles all
-// possible enum cases by returning. Annoyingly, GCC can complain about this.
+// possible enum cases by returning. Using this macro will stop GCC's
+// -Wreturn-type flag from issuing a warning about this situation.
 // Example:
 //     enum class OneOrTwo { kOne, kTwo };
 //
@@ -41,6 +42,8 @@
 //       }
 //       // If we didn't put this ABORT statement below, GCC would complain:
 //       //   warning: control reaches end of non-void function [-Wreturn-type]
+//       // We shouldn't reach this point unless someone makes a weird function
+//       // call like `ReturnOneOrTwo(static_cast<OneOrTwo>(3))`.
 //       ABORT_INVALID_ENUM(OneOrTwo, one_or_two)
 //     }
 #define ABORT_INVALID_ENUM(EnumType, enum_value) \

--- a/pbbslib/assert.h
+++ b/pbbslib/assert.h
@@ -25,6 +25,28 @@
     std::terminate(); \
   } while (false)
 
+// Prints out enum value and terminates the program.
+//
+// This is intended for use after a switch statement on an enum that handles all
+// possible enum cases by returning. Annoyingly, GCC can complain about this.
+// Example:
+//     enum class OneOrTwo { kOne, kTwo };
+//
+//     int ReturnOneOrTwo(OneOrTwo one_or_two) {
+//       switch (one_or_two) {
+//         case OneOrTwo::kOne:
+//           return 1;
+//         case OneOrTwo::kTwo:
+//           return 2;
+//       }
+//       // If we didn't put this ABORT statement below, GCC would complain:
+//       //   warning: control reaches end of non-void function [-Wreturn-type]
+//       ABORT_INVALID_ENUM(OneOrTwo, one_or_two)
+//     }
+#define ABORT_INVALID_ENUM(EnumType, enum_value) \
+  ABORT("Unexpected " #EnumType " value: " << \
+      static_cast<typename std::underlying_type<EnumType>::type>(enum_value));
+
 // Asserts on a condition, printing an error and terminating if the condition is
 // false.
 //


### PR DESCRIPTION
`[a]symmetric_vertex::intersect` assumes that the neighbor lists of each vertex are in sorted order. However, this is not necessarily the case. In particular,
- The AdjacencyGraph format that we read graphs in does not specify that neighbor lists are in sorted order. Therefore, a user could reasonably write a file in which they are not. Then when we read in the graph, the neighbor lists will remain in unsorted order.
- `sym_graph_from_edges` in `ligra/graph.h` does not sort neighbor lists.
  - this is how this issue came to my attention -- I was failing a unit test using a graph created by `graph_test::MakeUnweightedSymmetricGraph`, which calls `sym_graph_from_edges`.

This PR is a temporary patch to `graph_test::MakeUnweightedSymmetricGraph` to make unit test pass. It also adds to comments to `symmetric_vertex::intersect` documenting this assumption.

However, this issue should really be addressed in a more robust way. This is a sneaky assumption in `symmetric_vertex::intersect` that doesn't cause any seg faults but instead will lead to slightly wrong answers, and the user has no convenient way to validate that a graph's neighbor lists are all in sorted order. This affects:
- KTruss
- TriangleCounting
  - and by extension, CliqueCounting
- SCAN clustering (my work-in-progress PR)

Some possible solutions:
- Maintain that all graphs should have sorted neighbor lists
  - Sort neighbor lists in the graph constructor (might be expensive, O(m) time with integer sort)
  - Or sort neighbor lists in `graph_io.h` when we read in graphs or assert that they're sorted. Add a 
      function comment to `[a]symmetric_graph`'s constructor saying that neighbor lists must be sorted. (this feels error-prone)
- Add a function for sorting a graph's neighbor lists and let the user beware of incorrect `intersect` calls (also error-prone)
- Rewrite `symmetric_vertex::intersect` to not require sorted neighbor lists (expensive, I'd guess this will slow down TriangleCounting by a lot)

Feedback on what solution we should move forward with would be appreciated.



 