### PR TITLE
Connectivity: Create implementation files for common.h + connectit.h

### DIFF
--- a/benchmarks/Connectivity/BUILD
+++ b/benchmarks/Connectivity/BUILD
@@ -4,8 +4,13 @@ cc_library(
   "common.h",
   "connectit.h",
   ],
+  srcs = [
+  "common.cc",
+  "connectit.cc",
+  ],
   deps = [
   "//ligra/pbbslib:atomic_counter",
+  "//pbbslib:assert",
   ],
 )
 

--- a/benchmarks/Connectivity/Framework/mains/BUILD
+++ b/benchmarks/Connectivity/Framework/mains/BUILD
@@ -434,4 +434,7 @@ cc_library(
     hdrs = [
         "uf_utils.h",
     ],
+    deps = [
+        "//benchmarks/Connectivity:common",
+    ],
 )

--- a/benchmarks/Connectivity/Framework/mains/label_propagation.cc
+++ b/benchmarks/Connectivity/Framework/mains/label_propagation.cc
@@ -50,7 +50,7 @@ bool run_multiple_sample_only_alg(
     }
     return t;
   };
-  auto test_name = name + "; " + sampling_to_string<sampling_option>();
+  auto test_name = name + "; " + sampling_to_string(sampling_option);
   return run_multiple(G, rounds, correct, test_name, P, test);
 }
 

--- a/benchmarks/Connectivity/Framework/mains/liutarjan_bfs.cc
+++ b/benchmarks/Connectivity/Framework/mains/liutarjan_bfs.cc
@@ -60,7 +60,7 @@ namespace connectit {
         }
         return t;
       };
-      auto name = liu_tarjan_options_to_string<sampling_option, connect_option, simple_update_option, shortcut_option, alter_option>();
+      auto name = liu_tarjan_options_to_string(sampling_option, connect_option, simple_update_option, shortcut_option, alter_option);
       return run_multiple(G, rounds, correct, name, P, test);
     } else {
       auto test = [&] (Graph& graph, commandLine params, pbbs::sequence<parent>& correct_cc) {
@@ -92,7 +92,7 @@ namespace connectit {
         }
         return t;
       };
-      auto name = liu_tarjan_options_to_string<sampling_option, connect_option, simple_update_option, shortcut_option, alter_option>();
+      auto name = liu_tarjan_options_to_string(sampling_option, connect_option, simple_update_option, shortcut_option, alter_option);
       return run_multiple(G, rounds, correct, name, P, test);
     }
   }

--- a/benchmarks/Connectivity/Framework/mains/liutarjan_kout.cc
+++ b/benchmarks/Connectivity/Framework/mains/liutarjan_kout.cc
@@ -60,7 +60,7 @@ namespace connectit {
         }
         return t;
       };
-      auto name = liu_tarjan_options_to_string<sampling_option, connect_option, simple_update_option, shortcut_option, alter_option>();
+      auto name = liu_tarjan_options_to_string(sampling_option, connect_option, simple_update_option, shortcut_option, alter_option);
       return run_multiple(G, rounds, correct, name, P, test);
     } else {
       auto test = [&] (Graph& graph, commandLine params, pbbs::sequence<parent>& correct_cc) {
@@ -92,7 +92,7 @@ namespace connectit {
         }
         return t;
       };
-      auto name = liu_tarjan_options_to_string<sampling_option, connect_option, simple_update_option, shortcut_option, alter_option>();
+      auto name = liu_tarjan_options_to_string(sampling_option, connect_option, simple_update_option, shortcut_option, alter_option);
       return run_multiple(G, rounds, correct, name, P, test);
     }
   }

--- a/benchmarks/Connectivity/Framework/mains/liutarjan_ldd.cc
+++ b/benchmarks/Connectivity/Framework/mains/liutarjan_ldd.cc
@@ -60,7 +60,7 @@ namespace connectit {
         }
         return t;
       };
-      auto name = liu_tarjan_options_to_string<sampling_option, connect_option, simple_update_option, shortcut_option, alter_option>();
+      auto name = liu_tarjan_options_to_string(sampling_option, connect_option, simple_update_option, shortcut_option, alter_option);
       return run_multiple(G, rounds, correct, name, P, test);
     } else {
       auto test = [&] (Graph& graph, commandLine params, pbbs::sequence<parent>& correct_cc) {
@@ -92,7 +92,7 @@ namespace connectit {
         }
         return t;
       };
-      auto name = liu_tarjan_options_to_string<sampling_option, connect_option, simple_update_option, shortcut_option, alter_option>();
+      auto name = liu_tarjan_options_to_string(sampling_option, connect_option, simple_update_option, shortcut_option, alter_option);
       return run_multiple(G, rounds, correct, name, P, test);
     }
   }

--- a/benchmarks/Connectivity/Framework/mains/liutarjan_nosample.cc
+++ b/benchmarks/Connectivity/Framework/mains/liutarjan_nosample.cc
@@ -60,7 +60,7 @@ namespace connectit {
         }
         return t;
       };
-      auto name = liu_tarjan_options_to_string<sampling_option, connect_option, simple_update_option, shortcut_option, alter_option>();
+      auto name = liu_tarjan_options_to_string(sampling_option, connect_option, simple_update_option, shortcut_option, alter_option);
       return run_multiple(G, rounds, correct, name, P, test);
     } else {
       auto test = [&] (Graph& graph, commandLine params, pbbs::sequence<parent>& correct_cc) {
@@ -92,7 +92,7 @@ namespace connectit {
         }
         return t;
       };
-      auto name = liu_tarjan_options_to_string<sampling_option, connect_option, simple_update_option, shortcut_option, alter_option>();
+      auto name = liu_tarjan_options_to_string(sampling_option, connect_option, simple_update_option, shortcut_option, alter_option);
       return run_multiple(G, rounds, correct, name, P, test);
     }
   }

--- a/benchmarks/Connectivity/Framework/mains/shiloach_vishkin.cc
+++ b/benchmarks/Connectivity/Framework/mains/shiloach_vishkin.cc
@@ -49,7 +49,7 @@ bool run_multiple_sample_only_alg(
     }
     return t;
   };
-  auto test_name = name + "; " + sampling_to_string<sampling_option>();
+  auto test_name = name + "; " + sampling_to_string(sampling_option);
   return run_multiple(G, rounds, correct, test_name, P, test);
 }
 

--- a/benchmarks/Connectivity/Framework/mains/uf_utils.h
+++ b/benchmarks/Connectivity/Framework/mains/uf_utils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "benchmarks/Connectivity/common.h"
+
 namespace connectit {
   template<
     class Graph,

--- a/benchmarks/Connectivity/Framework/mains/uf_utils.h
+++ b/benchmarks/Connectivity/Framework/mains/uf_utils.h
@@ -30,7 +30,7 @@ namespace connectit {
       }
       return t;
     };
-    auto name = uf_options_to_string<sampling_option, find_option, unite_option>();
+    auto name = uf_options_to_string(sampling_option, find_option, unite_option);
     return run_multiple(G, rounds, correct, name, P, test);
   }
 
@@ -63,7 +63,7 @@ namespace connectit {
       }
       return t;
     };
-    auto name = uf_options_to_string<sampling_option, find_option, unite_option, splice_option>();
+    auto name = uf_options_to_string(sampling_option, find_option, unite_option, splice_option);
     return run_multiple(G, rounds, correct, name, P, test);
   }
 
@@ -92,7 +92,7 @@ namespace connectit {
       }
       return t;
     };
-    auto name = jayanti_options_to_string<sampling_option, find_option>();
+    auto name = jayanti_options_to_string(sampling_option, find_option);
     return run_multiple(G, rounds, correct, name, P, test);
   }
  } // namespace connectit

--- a/benchmarks/Connectivity/Incremental/mains/BUILD
+++ b/benchmarks/Connectivity/Incremental/mains/BUILD
@@ -211,4 +211,7 @@ cc_library(
 cc_library(
     name = "uf_utils",
     hdrs = ["uf_utils.h"],
+    deps = [
+        "//benchmarks/Connectivity:common",
+    ]
 )

--- a/benchmarks/Connectivity/Incremental/mains/lt_utils.h
+++ b/benchmarks/Connectivity/Incremental/mains/lt_utils.h
@@ -38,7 +38,7 @@ namespace connectit {
       return run_abstract_alg<Graph, decltype(alg), provides_initial_graph, /* reorder_batch = */true>(graph, n, updates, batch_size, insert_to_query, check, alg);
     };
 
-    auto name = liu_tarjan_options_to_string<no_sampling,connect_option,update_option,shortcut_option,alter_option>();
+    auto name = liu_tarjan_options_to_string(no_sampling,connect_option,update_option,shortcut_option,alter_option);
     return run_multiple(G, rounds, name, P, test);
   }
 } // connectit

--- a/benchmarks/Connectivity/Incremental/mains/uf_utils.h
+++ b/benchmarks/Connectivity/Incremental/mains/uf_utils.h
@@ -34,7 +34,7 @@ namespace connectit {
       return run_abstract_alg<Graph, decltype(alg), provides_initial_graph, /* reorder_batch = */false>(graph, n, updates, batch_size, insert_to_query, check, alg);
     };
 
-    auto name = uf_options_to_string<no_sampling, find_option, unite_option>();
+    auto name = uf_options_to_string(no_sampling, find_option, unite_option);
     return run_multiple(G, rounds, name, P, test);
   }
 
@@ -69,7 +69,7 @@ namespace connectit {
       }
     };
 
-    auto name = uf_options_to_string<no_sampling, find_option, unite_option, splice_option>();
+    auto name = uf_options_to_string(no_sampling, find_option, unite_option, splice_option);
     return run_multiple(G, rounds, name, P, test);
   }
 
@@ -93,7 +93,7 @@ namespace connectit {
       return run_abstract_alg<Graph, decltype(alg), provides_initial_graph, /* reorder_batch = */ false>(graph, n, updates, batch_size, insert_to_query, check, alg);
     };
 
-    auto name = jayanti_options_to_string<no_sampling, find_option>();
+    auto name = jayanti_options_to_string(no_sampling, find_option);
     return run_multiple(G, rounds, name, P, test);
   }
 } // connectit

--- a/benchmarks/Connectivity/Incremental/mains/uf_utils.h
+++ b/benchmarks/Connectivity/Incremental/mains/uf_utils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "benchmarks/Connectivity/connectit.h"
+
 namespace connectit {
   template<
     class Graph,

--- a/benchmarks/Connectivity/common.cc
+++ b/benchmarks/Connectivity/common.cc
@@ -1,0 +1,46 @@
+#include "benchmarks/Connectivity/common.h"
+
+atomic_max_counter<uintE> max_pathlen;
+atomic_sum_counter<size_t> total_pathlen;
+
+void report_pathlen(uintE pathlen) {
+#ifdef REPORT_PATH_LENGTHS
+  max_pathlen.update_value(pathlen);
+  total_pathlen.update_value(pathlen);
+#endif
+}
+
+pbbs::sequence<std::tuple<uintE, uintE, UpdateType>>
+annotate_updates_insert(pbbs::sequence<std::tuple<uintE, uintE>>& updates, size_t n) {
+  auto seq = pbbslib::make_sequence<std::tuple<uintE, uintE, UpdateType>>(n, [&] (size_t i) {
+      auto& ith = updates[i];
+      return std::make_tuple(std::get<0>(ith), std::get<1>(ith), insertion_type);
+  });
+  return seq;
+}
+
+pbbs::sequence<std::tuple<uintE, uintE, UpdateType>>
+annotate_updates(pbbs::sequence<std::tuple<uintE, uintE>>& updates, double insert_to_query, size_t n, bool permute) {
+  size_t result_size = updates.size()/insert_to_query;
+  if (insert_to_query > 1) {
+    std::cout << "Error: 0 < insert_to_query < 1" << std::endl;
+    abort();
+  }
+  auto result = pbbs::sequence<std::tuple<uintE, uintE, UpdateType>>(result_size);
+  auto rnd = pbbs::random();
+  parallel_for(0, updates.size(), [&] (size_t i) {
+    uintE u, v;
+    std::tie(u,v) = updates[i];
+      result[i] = std::make_tuple(u, v, insertion_type);
+  });
+  parallel_for(updates.size(), result.size(), [&] (size_t i) {
+    auto our_rnd = rnd.fork(i);
+    auto u = our_rnd.ith_rand(0) % n;
+    auto v = our_rnd.ith_rand(1) % n;
+    result[i] = std::make_tuple(u, v, query_type);
+  });
+  if (permute) {
+    return pbbs::random_shuffle(result);
+  }
+  return result;
+}

--- a/benchmarks/Connectivity/common.h
+++ b/benchmarks/Connectivity/common.h
@@ -9,17 +9,12 @@ using parent = uintE;
 
 using incremental_update = std::tuple<uintE, uintE, UpdateType> ;
 
-uintE largest_comp = UINT_E_MAX;
+constexpr uintE largest_comp = UINT_E_MAX;
 
-atomic_max_counter<uintE> max_pathlen;
-atomic_sum_counter<size_t> total_pathlen;
+extern atomic_max_counter<uintE> max_pathlen;
+extern atomic_sum_counter<size_t> total_pathlen;
 
-void report_pathlen(uintE pathlen) {
-#ifdef REPORT_PATH_LENGTHS
-  max_pathlen.update_value(pathlen);
-  total_pathlen.update_value(pathlen);
-#endif
-}
+void report_pathlen(uintE pathlen);
 
 template <class Seq>
 std::pair<pbbs::sequence<incremental_update>, size_t> reorder_updates(Seq& updates) {
@@ -45,35 +40,8 @@ std::pair<pbbs::sequence<incremental_update>, size_t> reorder_updates(Seq& updat
 //  return result;
 //}
 
-auto annotate_updates_insert(pbbs::sequence<std::tuple<uintE, uintE>>& updates, size_t n) {
-  auto seq = pbbslib::make_sequence<std::tuple<uintE, uintE, UpdateType>>(n, [&] (size_t i) {
-      auto& ith = updates[i];
-      return std::make_tuple(std::get<0>(ith), std::get<1>(ith), insertion_type);
-  });
-  return seq;
-}
+pbbs::sequence<std::tuple<uintE, uintE, UpdateType>>
+annotate_updates_insert(pbbs::sequence<std::tuple<uintE, uintE>>& updates, size_t n);
 
-auto annotate_updates(pbbs::sequence<std::tuple<uintE, uintE>>& updates, double insert_to_query, size_t n, bool permute = false) {
-  size_t result_size = updates.size()/insert_to_query;
-  if (insert_to_query > 1) {
-    std::cout << "Error: 0 < insert_to_query < 1" << std::endl;
-    abort();
-  }
-  auto result = pbbs::sequence<std::tuple<uintE, uintE, UpdateType>>(result_size);
-  auto rnd = pbbs::random();
-  parallel_for(0, updates.size(), [&] (size_t i) {
-    uintE u, v;
-    std::tie(u,v) = updates[i];
-      result[i] = std::make_tuple(u, v, insertion_type);
-  });
-  parallel_for(updates.size(), result.size(), [&] (size_t i) {
-    auto our_rnd = rnd.fork(i);
-    auto u = our_rnd.ith_rand(0) % n;
-    auto v = our_rnd.ith_rand(1) % n;
-    result[i] = std::make_tuple(u, v, query_type);
-  });
-  if (permute) {
-    return pbbs::random_shuffle(result);
-  }
-  return result;
-}
+pbbs::sequence<std::tuple<uintE, uintE, UpdateType>>
+annotate_updates(pbbs::sequence<std::tuple<uintE, uintE>>& updates, double insert_to_query, size_t n, bool permute = false);

--- a/benchmarks/Connectivity/connectit.cc
+++ b/benchmarks/Connectivity/connectit.cc
@@ -1,0 +1,25 @@
+#include "benchmarks/Connectivity/connectit.h"
+
+#include "pbbslib/assert.h"
+
+// Creates a case on `case_label` and returns `case_label` as a string in the
+// case.
+#define RETURN_CASE_LABEL(case_label) \
+  case case_label: \
+    return "case_label";
+
+namespace connectit {
+
+std::string find_to_string(FindOption find_option) {
+  switch (find_option) {
+    RETURN_CASE_LABEL(find_compress);
+    RETURN_CASE_LABEL(find_naive);
+    RETURN_CASE_LABEL(find_split);
+    RETURN_CASE_LABEL(find_halve);
+    RETURN_CASE_LABEL(find_atomic_split);
+    RETURN_CASE_LABEL(find_atomic_halve);
+  }
+  ABORT_INVALID_ENUM(FindOption, find_option);
+}
+
+} // namespace connectit

--- a/benchmarks/Connectivity/connectit.cc
+++ b/benchmarks/Connectivity/connectit.cc
@@ -78,7 +78,7 @@ std::string update_to_string(const LiuTarjanUpdateOption update_option) {
   ABORT_INVALID_ENUM(LiuTarjanUpdateOption, update_option);
 }
 
-std::string shortcut_to_string(const LiuTarjanShortcutOption shortcut_option) { 
+std::string shortcut_to_string(const LiuTarjanShortcutOption shortcut_option) {
   switch (shortcut_option) {
     RETURN_CASE_LABEL(shortcut);
     RETURN_CASE_LABEL(full_shortcut);
@@ -95,8 +95,8 @@ std::string alter_to_string(const LiuTarjanAlterOption alter_option) {
 }
 
 std::string uf_options_to_string(
-    const SamplingOption sampling_option, 
-    const FindOption find_option, 
+    const SamplingOption sampling_option,
+    const FindOption find_option,
     const UniteOption unite_option) {
   return "uf; sample="
     + sampling_to_string(sampling_option)
@@ -105,9 +105,9 @@ std::string uf_options_to_string(
 }
 
 std::string uf_options_to_string(
-    const SamplingOption sampling_option, 
-    const FindOption find_option, 
-    const UniteOption unite_option, 
+    const SamplingOption sampling_option,
+    const FindOption find_option,
+    const UniteOption unite_option,
     const SpliceOption splice_option) {
   return "uf; sample="
     + sampling_to_string(sampling_option)
@@ -117,7 +117,7 @@ std::string uf_options_to_string(
 }
 
 std::string jayanti_options_to_string(
-    const SamplingOption sampling_option, 
+    const SamplingOption sampling_option,
     const JayantiFindOption find_option) {
   return "jayanti; sample="
     + sampling_to_string(sampling_option)
@@ -136,4 +136,4 @@ std::string liu_tarjan_options_to_string(
     + "; alter=" + alter_to_string(alter_option);
 }
 
-} // namespace connectit
+}  // namespace connectit

--- a/benchmarks/Connectivity/connectit.cc
+++ b/benchmarks/Connectivity/connectit.cc
@@ -10,7 +10,7 @@
 
 namespace connectit {
 
-std::string find_to_string(FindOption find_option) {
+std::string find_to_string(const FindOption find_option) {
   switch (find_option) {
     RETURN_CASE_LABEL(find_compress);
     RETURN_CASE_LABEL(find_naive);
@@ -20,6 +20,120 @@ std::string find_to_string(FindOption find_option) {
     RETURN_CASE_LABEL(find_atomic_halve);
   }
   ABORT_INVALID_ENUM(FindOption, find_option);
+}
+
+std::string splice_to_string(const SpliceOption splice_option) {
+  switch (splice_option) {
+    RETURN_CASE_LABEL(split_atomic_one);
+    RETURN_CASE_LABEL(halve_atomic_one);
+    RETURN_CASE_LABEL(splice_simple);
+    RETURN_CASE_LABEL(splice_atomic);
+  }
+  ABORT_INVALID_ENUM(SpliceOption, splice_option);
+}
+
+std::string unite_to_string(const UniteOption unite_option) {
+  switch (unite_option) {
+    RETURN_CASE_LABEL(unite);
+    RETURN_CASE_LABEL(unite_early);
+    RETURN_CASE_LABEL(unite_nd);
+    RETURN_CASE_LABEL(unite_rem_lock);
+    RETURN_CASE_LABEL(unite_rem_cas);
+  }
+  ABORT_INVALID_ENUM(UniteOption, unite_option);
+}
+
+std::string sampling_to_string(const SamplingOption sampling_option) {
+  switch (sampling_option) {
+    RETURN_CASE_LABEL(sample_kout);
+    RETURN_CASE_LABEL(sample_bfs);
+    RETURN_CASE_LABEL(sample_ldd);
+    RETURN_CASE_LABEL(no_sampling);
+  }
+  ABORT_INVALID_ENUM(SamplingOption, sampling_option);
+}
+
+std::string jayanti_find_to_string(const JayantiFindOption find_option) {
+  switch (find_option) {
+    RETURN_CASE_LABEL(find_twotrysplit);
+    RETURN_CASE_LABEL(find_simple);
+  }
+  ABORT_INVALID_ENUM(JayantiFindOption, find_option);
+}
+
+std::string connect_to_string(const LiuTarjanConnectOption connect_option) {
+  switch (connect_option) {
+    RETURN_CASE_LABEL(simple_connect);
+    RETURN_CASE_LABEL(parent_connect);
+    RETURN_CASE_LABEL(extended_connect);
+  }
+  ABORT_INVALID_ENUM(LiuTarjanConnectOption, connect_option);
+}
+
+std::string update_to_string(const LiuTarjanUpdateOption update_option) {
+  switch (update_option) {
+    RETURN_CASE_LABEL(simple_update);
+    RETURN_CASE_LABEL(root_update);
+  }
+  ABORT_INVALID_ENUM(LiuTarjanUpdateOption, update_option);
+}
+
+std::string shortcut_to_string(const LiuTarjanShortcutOption shortcut_option) { 
+  switch (shortcut_option) {
+    RETURN_CASE_LABEL(shortcut);
+    RETURN_CASE_LABEL(full_shortcut);
+  }
+  ABORT_INVALID_ENUM(LiuTarjanShortcutOption, shortcut_option);
+}
+
+std::string alter_to_string(const LiuTarjanAlterOption alter_option) {
+  switch (alter_option) {
+    RETURN_CASE_LABEL(alter);
+    RETURN_CASE_LABEL(no_alter);
+  }
+  ABORT_INVALID_ENUM(LiuTarjanAlterOption, alter_option);
+}
+
+std::string uf_options_to_string(
+    const SamplingOption sampling_option, 
+    const FindOption find_option, 
+    const UniteOption unite_option) {
+  return "uf; sample="
+    + sampling_to_string(sampling_option)
+    + "; unite=" + unite_to_string(unite_option)
+    + "; find=" + find_to_string(find_option);
+}
+
+std::string uf_options_to_string(
+    const SamplingOption sampling_option, 
+    const FindOption find_option, 
+    const UniteOption unite_option, 
+    const SpliceOption splice_option) {
+  return "uf; sample="
+    + sampling_to_string(sampling_option)
+    + "; unite=" + unite_to_string(unite_option)
+    + "; find=" + find_to_string(find_option) +
+    + "; splice=" + splice_to_string(splice_option);
+}
+
+std::string jayanti_options_to_string(
+    const SamplingOption sampling_option, 
+    const JayantiFindOption find_option) {
+  return "jayanti; sample="
+    + sampling_to_string(sampling_option)
+    + "; find=" + jayanti_find_to_string(find_option);
+}
+std::string liu_tarjan_options_to_string(
+    const SamplingOption sampling_option,
+    const LiuTarjanConnectOption connect_option,
+    const LiuTarjanUpdateOption update_option,
+    const LiuTarjanShortcutOption shortcut_option,
+    const LiuTarjanAlterOption alter_option) {
+  return "liu_tarjan; sample=" + sampling_to_string(sampling_option)
+    + "; connect=" + connect_to_string(connect_option)
+    + "; update=" + update_to_string(update_option)
+    + "; shortcut=" + shortcut_to_string(shortcut_option)
+    + "; alter=" + alter_to_string(alter_option);
 }
 
 } // namespace connectit

--- a/benchmarks/Connectivity/connectit.cc
+++ b/benchmarks/Connectivity/connectit.cc
@@ -6,7 +6,7 @@
 // case.
 #define RETURN_CASE_LABEL(case_label) \
   case case_label: \
-    return "case_label";
+    return #case_label;
 
 namespace connectit {
 

--- a/benchmarks/Connectivity/connectit.h
+++ b/benchmarks/Connectivity/connectit.h
@@ -58,141 +58,28 @@ enum UpdateType {
 
 namespace connectit {
 
+  // Converts enum to string.
   std::string find_to_string(FindOption);
+  std::string splice_to_string(SpliceOption);
+  std::string unite_to_string(UniteOption);
+  std::string sampling_to_string(SamplingOption);
+  std::string jayanti_find_to_string(JayantiFindOption);
+  std::string connect_to_string(LiuTarjanConnectOption);
+  std::string update_to_string(LiuTarjanUpdateOption);
+  std::string shortcut_to_string(LiuTarjanShortcutOption);
+  std::string alter_to_string(LiuTarjanAlterOption);
 
-  template <SpliceOption splice_option>
-  auto splice_to_string() {
-    if constexpr (splice_option == split_atomic_one) {
-      return "split_atomic_one";
-    } else if constexpr (splice_option == halve_atomic_one) {
-      return "halve_atomic_one";
-    } else {
-      return "splice_atomic";
-    }
-  };
-
-  template <UniteOption unite_option>
-  std::string unite_to_string() {
-    if constexpr (unite_option == unite) {
-      return "unite";
-    } else if constexpr (unite_option == unite_early) {
-      return "unite_early";
-    } else if constexpr (unite_option == unite_nd) {
-      return "unite_nd";
-    } else if constexpr (unite_option == unite_rem_lock) {
-      return "unite_rem_lock";
-    } else if constexpr (unite_option == unite_rem_cas) {
-      return "unite_rem_cas";
-    } else {
-      abort();
-    }
-    return "";
-  }
-
-  template <SamplingOption sampling_option>
-  std::string sampling_to_string() {
-    if constexpr (sampling_option == sample_kout) {
-      return "kout";
-    } else if constexpr (sampling_option == sample_bfs) {
-      return "bfs";
-    } else if constexpr (sampling_option == sample_ldd) {
-      return "ldd";
-    } else {
-      return "no_sampling";
-    }
-  }
-
-  template <SamplingOption sampling_option, FindOption find_option, UniteOption unite_option>
-  std::string uf_options_to_string() {
-    return "uf; sample="
-      + sampling_to_string<sampling_option>()
-      + "; unite=" + unite_to_string<unite_option>()
-      + "; find=" + find_to_string(find_option);
-  };
-
-  template <SamplingOption sampling_option, FindOption find_option, UniteOption unite_option, SpliceOption splice_option>
-  std::string uf_options_to_string() {
-    return "uf; sample="
-      + sampling_to_string<sampling_option>()
-      + "; unite=" + unite_to_string<unite_option>()
-      + "; find=" + find_to_string(find_option) +
-      + "; splice=" + splice_to_string<splice_option>();
-  };
-
-  template <JayantiFindOption find_option>
-  auto jayanti_find_to_string() {
-    if constexpr (find_option == find_twotrysplit) {
-      return "find_twotrysplitting";
-    } else {
-      return "find_simple";
-    }
-  }
-
-  template <SamplingOption sampling_option, JayantiFindOption find_option>
-  std::string jayanti_options_to_string() {
-    return "jayanti; sample="
-      + sampling_to_string<sampling_option>()
-      + "; find=" + jayanti_find_to_string<find_option>();
-  }
-
-  template <LiuTarjanConnectOption connect_option>
-  auto connect_to_string() {
-    if constexpr (connect_option == simple_connect) {
-      return "connect";
-    } else if constexpr (connect_option == parent_connect) {
-      return "parent_connect";
-    } else if constexpr (connect_option == extended_connect) {
-      return "extended_connect";
-    } else {
-      abort();
-    }
-  }
-
-  template <LiuTarjanUpdateOption update_option>
-  auto update_to_string() {
-    if constexpr (update_option == simple_update) {
-      return "simple_update";
-    } else if constexpr (update_option == root_update) {
-      return "root_update";
-    } else {
-      abort();
-    }
-  }
-
-  template <LiuTarjanShortcutOption shortcut_option>
-  auto shortcut_to_string() {
-    if constexpr (shortcut_option == shortcut) {
-      return "shortcut";
-    } else if constexpr (shortcut_option == full_shortcut) {
-      return "full_shortcut";
-    } else {
-      abort();
-    }
-  }
-
-  template <LiuTarjanAlterOption alter_option>
-  auto alter_to_string() {
-    if constexpr (alter_option == alter) {
-      return "alter";
-    } else {
-      return "no_alter";
-    }
-  }
-
-  template <
-    SamplingOption sampling_option,
-    LiuTarjanConnectOption connect_option,
-    LiuTarjanUpdateOption update_option,
-    LiuTarjanShortcutOption shortcut_option,
-    LiuTarjanAlterOption alter_option>
-  std::string liu_tarjan_options_to_string() {
-    return "liu_tarjan; sample=" + sampling_to_string<sampling_option>()
-      + "; connect=" + connect_to_string<connect_option>()
-      + "; update=" + update_to_string<update_option>()
-      + "; shortcut=" + shortcut_to_string<shortcut_option>()
-      + "; alter=" + alter_to_string<alter_option>();
-  }
-
+  std::string uf_options_to_string(SamplingOption, FindOption, UniteOption);
+  std::string uf_options_to_string(
+      SamplingOption, FindOption, UniteOption, SpliceOption);
+  std::string jayanti_options_to_string(
+      SamplingOption sampling_option, JayantiFindOption find_option);
+  std::string liu_tarjan_options_to_string(
+      SamplingOption,
+      LiuTarjanConnectOption,
+      LiuTarjanUpdateOption,
+      LiuTarjanShortcutOption,
+      LiuTarjanAlterOption);
 
   // From gapbs/cc.c, Thanks to S. Beamer + M. Sutton for the original code this
   // snippet is based on.

--- a/benchmarks/Connectivity/connectit.h
+++ b/benchmarks/Connectivity/connectit.h
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <limits.h>
 #include <algorithm>
+#include <string>
 #include <unordered_map>
 #include <random>
 

--- a/benchmarks/Connectivity/connectit.h
+++ b/benchmarks/Connectivity/connectit.h
@@ -58,25 +58,7 @@ enum UpdateType {
 
 namespace connectit {
 
-  template <FindOption find_option>
-  std::string find_to_string() {
-    if constexpr (find_option == find_compress) {
-      return "find_compress";
-    } else if constexpr (find_option == find_naive) {
-      return "find_naive";
-    } else if constexpr (find_option == find_split) {
-      return "find_split";
-    } else if constexpr (find_option == find_halve) {
-      return "find_halve";
-    } else if constexpr (find_option == find_atomic_split) {
-      return "find_atomic_split";
-    } else if constexpr (find_option == find_atomic_halve) {
-      return "find_atomic_halve";
-    } else {
-      abort();
-      return "";
-    }
-  }
+  std::string find_to_string(FindOption);
 
   template <SpliceOption splice_option>
   auto splice_to_string() {
@@ -125,7 +107,7 @@ namespace connectit {
     return "uf; sample="
       + sampling_to_string<sampling_option>()
       + "; unite=" + unite_to_string<unite_option>()
-      + "; find=" + find_to_string<find_option>();
+      + "; find=" + find_to_string(find_option);
   };
 
   template <SamplingOption sampling_option, FindOption find_option, UniteOption unite_option, SpliceOption splice_option>
@@ -133,7 +115,7 @@ namespace connectit {
     return "uf; sample="
       + sampling_to_string<sampling_option>()
       + "; unite=" + unite_to_string<unite_option>()
-      + "; find=" + find_to_string<find_option>() +
+      + "; find=" + find_to_string(find_option) +
       + "; splice=" + splice_to_string<splice_option>();
   };
 


### PR DESCRIPTION
This PR creates `common.cc` and `connectit.cc`, moving some function definitions from the respective header files to those implementation files. I de-templatized some functions along the way.

Initially, this PR was going to be a quest to de-templatize a bunch of functions in `benchmarks/Connectivity/Incremental` and `benchmarks/Connectivity/Framework`. I wanted to see whether this would reduce the compilation time of the binaries in these directories. These binaries collectively take a long time to compile on CI because there are so many binaries (on a machine with more parallelism capacity it's not as much of an issue, but CI runs with two threads). A lot of these functions take enums and booleans as template arguments rather than function arguments so that they can case on them at compile time, but many of these functions are large enough that the runtime performance benefit of this is likely negligible. It looks like doing all this de-templatization would be somewhat time consuming, though, and I'm not actually sure that it would reduce compilation time, so I've elected to not bother with it.