### PR TITLE
seq: Give operator[]  const and non-const overloads

### DIFF
--- a/benchmarks/CliqueCounting/Clique.h
+++ b/benchmarks/CliqueCounting/Clique.h
@@ -76,7 +76,7 @@ pbbs::sequence<uintE> get_ordering(Graph& GA, long order_type, double epsilon = 
   else if (order_type == 2) {
     auto rank = sequence<uintE>(n, [&](size_t i) { return i; });
     auto kcore = KCore(GA);
-    auto get_core = [&](uintE& p) -> uintE { return kcore[p]; };
+    auto get_core = [&](uintE p) -> uintE { return kcore[p]; };
     pbbs::integer_sort_inplace(rank.slice(), get_core);
     return rank;
   }

--- a/benchmarks/Connectivity/LiuTarjan/Connectivity.h
+++ b/benchmarks/Connectivity/LiuTarjan/Connectivity.h
@@ -275,7 +275,7 @@ struct LiuTarjanAlgorithm {
           }
         });
 
-        auto new_inserts = pbbs::filter(inserts, [&] (edge& e) {
+        auto new_inserts = pbbs::filter(inserts, [&] (const edge& e) {
           return e != nullary_edge;
         });
         inserts = new_inserts;

--- a/benchmarks/DegeneracyOrder/BarenboimElkin08/DegeneracyOrder.h
+++ b/benchmarks/DegeneracyOrder/BarenboimElkin08/DegeneracyOrder.h
@@ -24,7 +24,7 @@ inline sequence<uintE> DegeneracyOrder(Graph& GA, double epsilon=0.1, bool appro
   auto em = EdgeMap<uintE, Graph>(GA, std::make_tuple(UINT_E_MAX, 0),
                                       (size_t)GA.m / 50);
   auto get_deg =
-      [&](uintE& p) -> uintE { return D[p] < deg_cutoff; };
+      [&](uintE p) -> uintE { return D[p] < deg_cutoff; };
   size_t start = 0;
   while (start < n) {
     // move all vert with deg < deg_cutoff in the front

--- a/benchmarks/DegeneracyOrder/GoodrichPszona11/DegeneracyOrder.h
+++ b/benchmarks/DegeneracyOrder/GoodrichPszona11/DegeneracyOrder.h
@@ -100,7 +100,7 @@ inline sequence<uintE> DegeneracyOrder_intsort(Graph& GA, double epsilon=0.001) 
   auto em = EdgeMap<uintE, Graph>(GA, std::make_tuple(UINT_E_MAX, 0),
                                       (size_t)GA.m / 20);
   auto get_deg =
-      [&](uintE& p) -> uintE { return D[p]; };
+      [&](uintE p) -> uintE { return D[p]; };
   for (size_t start = 0; start < n; start += ns) {
     // sort vertices in GA by degree, from start to n
     integer_sort_inplace(sortD.slice(start, n), get_deg);

--- a/ligra/pbbslib/sparse_additive_map.h
+++ b/ligra/pbbslib/sparse_additive_map.h
@@ -119,7 +119,7 @@ class sparse_additive_map {
 
   auto entries() {
     // T* out = pbbslib::new_array_no_init<T>(m);
-    auto pred = [&](T& t) { return std::get<0>(t) != empty_key; };
+    auto pred = [&](const T& t) { return std::get<0>(t) != empty_key; };
     auto table_seq = pbbslib::make_sequence<T>(table, m);
     return pbbslib::filter(table_seq, pred);
 //    size_t new_m = pbbslib::filterf(table, out, m, pred);

--- a/ligra/pbbslib/sparse_table.h
+++ b/ligra/pbbslib/sparse_table.h
@@ -245,7 +245,7 @@ class sparse_table {
   }
 
   sequence<T> entries() {
-    auto pred = [&](T& t) { return std::get<0>(t) != empty_key; };
+    auto pred = [&](const T& t) { return std::get<0>(t) != empty_key; };
     auto table_seq = pbbslib::make_sequence<T>(table, m);
     return pbbslib::filter(table_seq, pred);
   }

--- a/ligra/vertex.h
+++ b/ligra/vertex.h
@@ -75,8 +75,8 @@ size_t seq_merge_full(SeqA& A, SeqB& B, F& f) {
   size_t i = 0, j = 0;
   size_t ct = 0;
   while (i < nA && j < nB) {
-    T& a = A[i];
-    T& b = B[j];
+    const T& a = A[i];
+    const T& b = B[j];
     if (a == b) {
       f(a);
       i++;

--- a/pbbslib/seq.h
+++ b/pbbslib/seq.h
@@ -36,7 +36,8 @@ struct range {
   using const_iterator = iterator;
   range(){};
   range(iterator _s, iterator _e) : s(_s), e(_e){};
-  value_type& operator[](const size_t i) const { return s[i]; }
+  value_type& operator[](const size_t i) { return s[i]; }
+  const value_type& operator[](const size_t i) const { return s[i]; }
   range slice(size_t ss, size_t ee) const { return range(s + ss, s + ee); }
   range slice() const { return range(s, e); };
   size_t size() const { return e - s; }
@@ -184,7 +185,8 @@ struct sequence {
 
   ~sequence() { clear(); }
 
-  value_type& operator[](const size_t i) const { return s[i]; }
+  const value_type& operator[](const size_t i) const { return s[i]; }
+  value_type& operator[](const size_t i) { return s[i]; }
 
   range<value_type*> slice(size_t ss, size_t ee) const {
     return range<value_type*>(s + ss, s + ee);


### PR DESCRIPTION
`pbbs::range` and `pbbs::sequence` have a `T& operator[](size_t) const` operator, which has the odd effect that you can write to indices in a const `range`/`sequence`. 

This PR redefines `operator[]` on `pbbs::range` and `pbbs::sequence` so that you can write to indices in a non-`const` `range`/`sequence` but you can only read indices in a `const` `range`/`sequence`.

This should be a no-op in terms of runtime behavior.